### PR TITLE
Fix Linux SkiaSharp native asset resolution for net8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
     <PackageVersion Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="$(SkiaSharpVersion)" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="$(SkiaSharpVersion)" />
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />

--- a/integration/Effector.PackageIntegration.Tests/PackageIntegrationTests.cs
+++ b/integration/Effector.PackageIntegration.Tests/PackageIntegrationTests.cs
@@ -1,7 +1,10 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
@@ -44,6 +47,26 @@ public sealed class PackageIntegrationTests
         {
             Assert.IsAssignableFrom<IEffect>(new PackageTintEffect());
         });
+    }
+
+    [Fact]
+    public void NuGetConsumedApp_RestoreGraph_Aligns_LinuxNativeAssets_With_SkiaSharp()
+    {
+        var restoredPackageVersions = ReadRestoredPackageVersions(
+            Path.Combine(
+                GetPackageIntegrationTestsProjectDirectory(),
+                "..",
+                "Effector.PackageIntegration.App",
+                "obj",
+                "project.assets.json"));
+
+        Assert.True(
+            restoredPackageVersions.TryGetValue("SkiaSharp", out var skiaSharpVersion),
+            "Expected the integration app restore graph to include SkiaSharp.");
+        Assert.True(
+            restoredPackageVersions.TryGetValue("SkiaSharp.NativeAssets.Linux", out var linuxNativeAssetsVersion),
+            "Expected the integration app restore graph to include SkiaSharp.NativeAssets.Linux.");
+        Assert.Equal(skiaSharpVersion, linuxNativeAssetsVersion);
     }
 
     [Fact]
@@ -153,5 +176,33 @@ public sealed class PackageIntegrationTests
 
         Directory.CreateDirectory(root);
         return Path.Combine(root, fileName);
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadRestoredPackageVersions(string assetsFilePath)
+    {
+        Assert.True(File.Exists(assetsFilePath), $"Expected restore assets file at '{assetsFilePath}'.");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(assetsFilePath));
+        Assert.True(
+            document.RootElement.TryGetProperty("libraries", out var libraries),
+            $"Expected restore assets file '{assetsFilePath}' to contain a 'libraries' section.");
+
+        var packageVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var library in libraries.EnumerateObject())
+        {
+            var separatorIndex = library.Name.LastIndexOf('/');
+            Assert.True(separatorIndex > 0, $"Unexpected NuGet library key '{library.Name}'.");
+
+            packageVersions[library.Name[..separatorIndex]] = library.Name[(separatorIndex + 1)..];
+        }
+
+        return packageVersions;
+    }
+
+    private static string GetPackageIntegrationTestsProjectDirectory([CallerFilePath] string sourceFilePath = "")
+    {
+        var projectDirectory = Path.GetDirectoryName(sourceFilePath);
+        Assert.False(string.IsNullOrWhiteSpace(projectDirectory));
+        return projectDirectory!;
     }
 }

--- a/src/Effector/Effector.csproj
+++ b/src/Effector/Effector.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <Target Name="Effector_BuildSelfWeaver"


### PR DESCRIPTION
# PR Summary: Fix Linux SkiaSharp Native Asset Resolution for `net8.0`

## Branch

- `fix/issue-2-linux-native-assets`

## Related Issue

- [Issue #2](https://github.com/wieslawsoltes/Effector/issues/2)

## Problem

When consuming Effector on Linux with `net8.0`, the application could fail at startup with a SkiaSharp managed/native version mismatch:

```text
System.InvalidOperationException: The version of the native libSkiaSharp library (88.1) is incompatible with this version of SkiaSharp.
Supported versions of the native libSkiaSharp library are in the range [119.0, 120.0).
```

Effector depends on `SkiaSharp` `3.119.2`, while `Avalonia.Skia` `11.3.12` still brings in `SkiaSharp` `2.88.9` and `SkiaSharp.NativeAssets.Linux` `2.88.9`. NuGet correctly unified the managed `SkiaSharp` package to `3.119.2`, but Linux native assets were still allowed to resolve from the older Avalonia dependency chain because Effector’s package metadata did not explicitly declare `SkiaSharp.NativeAssets.Linux`.

## Root Cause

The generated Effector `.nupkg` contained this `net8.0` dependency group:

- `Avalonia` `11.3.12`
- `SkiaSharp` `3.119.2`

It did not include:

- `SkiaSharp.NativeAssets.Linux` `3.119.2`

That omission meant Linux consumers could end up with:

- managed `SkiaSharp` `3.119.2`
- native `libSkiaSharp.so` from `SkiaSharp.NativeAssets.Linux` `2.88.9`

This is the exact mismatch described in the issue.

## Fix

### Package metadata

The package metadata was updated so Effector now explicitly depends on `SkiaSharp.NativeAssets.Linux` for `net8.0`.

Changes:

- Added `SkiaSharp.NativeAssets.Linux` to central package version management in `Directory.Packages.props`.
- Added a `net8.0`-scoped package reference in `src/Effector/Effector.csproj`.

Result:

- the generated nuspec now contains `SkiaSharp.NativeAssets.Linux` `3.119.2` in the `net8.0` dependency group
- the `.NETStandard2.0` dependency group remains unchanged

### Regression coverage

Added a package-integration regression test that reads the consuming app’s `project.assets.json` and asserts:

- `SkiaSharp` is present
- `SkiaSharp.NativeAssets.Linux` is present
- both resolve to the same version

This protects against future packaging regressions where the managed SkiaSharp package version could diverge from the Linux native assets version in the consumer restore graph.

## Commits

1. `498b060` `Add Linux SkiaSharp native asset dependency for net8.0`
2. `68c32df` `Add restore-graph coverage for Linux native assets`

## Verification

### Package inspection

Packed a local test package and inspected the generated nuspec.

Verified outcome:

- `net8.0` dependency group now includes `SkiaSharp.NativeAssets.Linux` `3.119.2`

### Consumer restore graph

Restored the integration app against a local feed using a throwaway package version:

- `0.2.0-issue2test`

Verified in `integration/Effector.PackageIntegration.App/obj/project.assets.json`:

- `SkiaSharp/3.119.2`
- `SkiaSharp.NativeAssets.Linux/3.119.2`
- `SkiaSharp.NativeAssets.macOS/3.119.2`

This confirms the Linux native assets package now resolves alongside the unified managed SkiaSharp version.

### Build and test

Executed:

```bash
dotnet pack src/Effector/Effector.csproj -c Release -m:1 -p:GeneratePackageOnBuild=false -p:Version=0.2.0-issue2test -o artifacts/local-feed
dotnet restore integration/Effector.PackageIntegration.App/Effector.PackageIntegration.App.csproj --configfile integration/NuGet.config --no-cache -p:EffectorPackageVersion=0.2.0-issue2test
dotnet restore integration/Effector.PackageIntegration.Tests/Effector.PackageIntegration.Tests.csproj --configfile integration/NuGet.config --no-cache -p:EffectorPackageVersion=0.2.0-issue2test
dotnet build integration/Effector.PackageIntegration.Tests/Effector.PackageIntegration.Tests.csproj -c Release -m:1 --no-restore -p:EffectorPackageVersion=0.2.0-issue2test
DYLD_LIBRARY_PATH="$PWD/integration/Effector.PackageIntegration.Tests/bin/Release/net8.0/runtimes/osx/native" dotnet test integration/Effector.PackageIntegration.Tests/Effector.PackageIntegration.Tests.csproj -c Release --no-build --logger "console;verbosity=minimal" -p:EffectorPackageVersion=0.2.0-issue2test
```

Result:

- package built successfully
- integration consumer restore succeeded
- integration test build succeeded
- package integration tests passed: `3/3`

## Notes

- The test environment here was macOS, so runtime validation was performed through the existing macOS package integration path plus restore-graph inspection of the Linux native asset dependency.
- An existing nullable warning remains during pack/build:
  - `src/Effector/EffectorRuntime.cs(440,23): warning CS8602`
  - this warning predates the fix and was not changed by this work
