### PR TITLE
Fix Android APK builds by patching Avalonia ABI asset assemblies

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The NuGet package ships `buildTransitive` targets. On consuming projects Effecto
 
 - weaves the compiled consumer assembly after `CoreCompile`
 - patches app-local `Avalonia.Base.dll` and `Avalonia.Skia.dll` after build output copy
+- patches Android ABI asset copies after `_PrepareAssemblies` so packaged APKs use the patched Avalonia binaries
 - patches publish output
 - patches the NativeAOT ILC input assemblies before native compilation
 

--- a/plan/avalonia-custom-effects.md
+++ b/plan/avalonia-custom-effects.md
@@ -87,6 +87,8 @@ The runtime shader path is deliberately scoped to procedural overlays in v1. Dur
 - targets execute:
   - `AfterTargets="CoreCompile"`
   - `AfterTargets="CopyFilesToOutputDirectory"` for `Avalonia.Base.dll` / `Avalonia.Skia.dll` in `$(TargetDir)`
+  - `AfterTargets="_PrepareAssemblies"` / `BeforeTargets="_BuildApkEmbed"` for Android ABI asset copies in `$(IntermediateOutputPath)android/assets/*/`
+  - `AfterTargets="ComputeIlcCompileInputs"` / `BeforeTargets="WriteIlcRspFileForCompilation"` for NativeAOT `@(IlcReference)` inputs
   - `AfterTargets="Publish"` for `Avalonia.Base.dll` / `Avalonia.Skia.dll` in `$(PublishDir)`
 
 ### Metadata-First Migration Plan

--- a/src/Effector.Build/buildTransitive/Effector.Build.targets
+++ b/src/Effector.Build/buildTransitive/Effector.Build.targets
@@ -8,6 +8,7 @@
     <_EffectorLocalRuntimeRefObjPath Condition="'$(_EffectorLocalRuntimeRefObjPath)' == ''">$([System.IO.Path]::GetFullPath('$(BaseIntermediateOutputPath)effector-runtime-ref\'))</_EffectorLocalRuntimeRefObjPath>
     <_EffectorTaskAssemblyPath Condition="'$(_EffectorTaskAssemblyPath)' == '' and Exists('$(_EffectorPackagedTaskAssemblyPath)')">$(_EffectorPackagedTaskAssemblyPath)</_EffectorTaskAssemblyPath>
     <_EffectorTaskAssemblyPath Condition="'$(_EffectorTaskAssemblyPath)' == '' and Exists('$(_EffectorLocalTaskProjectPath)')">$(_EffectorLocalTaskAssemblyPath)</_EffectorTaskAssemblyPath>
+    <_EffectorAndroidAssetsDir Condition="'$(_EffectorAndroidAssetsDir)' == ''">$([System.IO.Path]::Combine('$(IntermediateOutputPath)', 'android', 'assets'))</_EffectorAndroidAssetsDir>
   </PropertyGroup>
 
   <UsingTask TaskName="Effector.Build.Tasks.WeaveSkiaEffectsTask"
@@ -55,6 +56,26 @@
                                  Strict="$(EffectorStrict)"
                                  Verbose="$(EffectorVerbose)"
                                  SupportedAvaloniaVersion="$(EffectorSupportedAvaloniaVersion)" />
+  </Target>
+
+  <Target Name="Effector_PatchAvaloniaAndroidAssemblies"
+          AfterTargets="_PrepareAssemblies"
+          BeforeTargets="_BuildApkEmbed"
+          DependsOnTargets="Effector_BuildLocalTask"
+          Condition="'$(EffectorEnabled)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(AndroidApplication)' == 'true' and Exists('$(_EffectorAndroidAssetsDir)')">
+    <ItemGroup>
+      <_EffectorAndroidAvaloniaBase Include="$(_EffectorAndroidAssetsDir)/*/Avalonia.Base.dll" />
+      <_EffectorAndroidAvaloniaPatch Include="@(_EffectorAndroidAvaloniaBase)">
+        <EffectorAvaloniaSkiaAssemblyPath>%(RootDir)%(Directory)Avalonia.Skia.dll</EffectorAvaloniaSkiaAssemblyPath>
+      </_EffectorAndroidAvaloniaPatch>
+    </ItemGroup>
+
+    <PatchAvaloniaAssembliesTask AvaloniaBaseAssemblyPath="%(_EffectorAndroidAvaloniaPatch.FullPath)"
+                                 AvaloniaSkiaAssemblyPath="%(_EffectorAndroidAvaloniaPatch.EffectorAvaloniaSkiaAssemblyPath)"
+                                 Strict="$(EffectorStrict)"
+                                 Verbose="$(EffectorVerbose)"
+                                 SupportedAvaloniaVersion="$(EffectorSupportedAvaloniaVersion)"
+                                 Condition="'@(_EffectorAndroidAvaloniaPatch)' != ''" />
   </Target>
 
   <Target Name="Effector_PatchAvaloniaAotCompileAssemblies"

--- a/tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs
+++ b/tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Xml.Linq;
 using Avalonia.Media;
@@ -113,42 +115,41 @@ public sealed class EffectorBuildTargetsTests
 
     private static string GetBuildTargetsPath([CallerFilePath] string sourceFilePath = "")
     {
-        var testProjectDirectory = Path.GetDirectoryName(sourceFilePath);
-        Assert.False(string.IsNullOrWhiteSpace(testProjectDirectory));
-
-        return Path.GetFullPath(Path.Combine(
-            testProjectDirectory!,
-            "..",
-            "..",
-            "src",
-            "Effector.Build",
-            "buildTransitive",
-            "Effector.Build.targets"));
+        return ResolveRepositoryFile(
+            new[]
+            {
+                "src",
+                "Effector.Build",
+                "buildTransitive",
+                "Effector.Build.targets"
+            },
+            sourceFilePath);
     }
 
     private static string GetBuiltTaskAssemblyPath([CallerFilePath] string sourceFilePath = "")
     {
-        var testProjectDirectory = Path.GetDirectoryName(sourceFilePath);
-        Assert.False(string.IsNullOrWhiteSpace(testProjectDirectory));
-
         var configuration =
             AppContext.BaseDirectory.Contains($"{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
                 ? "Release"
                 : "Debug";
 
-        var taskAssemblyPath = Path.GetFullPath(Path.Combine(
-            testProjectDirectory!,
-            "..",
-            "..",
-            "src",
-            "Effector.Build.Tasks",
-            "bin",
-            configuration,
-            "netstandard2.0",
-            "Effector.Build.Tasks.dll"));
+        var copiedTaskAssemblyPath = Path.Combine(AppContext.BaseDirectory, "Effector.Build.Tasks.dll");
+        if (File.Exists(copiedTaskAssemblyPath))
+        {
+            return copiedTaskAssemblyPath;
+        }
 
-        Assert.True(File.Exists(taskAssemblyPath), $"Expected built task assembly at '{taskAssemblyPath}'.");
-        return taskAssemblyPath;
+        return ResolveRepositoryFile(
+            new[]
+            {
+                "src",
+                "Effector.Build.Tasks",
+                "bin",
+                configuration,
+                "netstandard2.0",
+                "Effector.Build.Tasks.dll"
+            },
+            sourceFilePath);
     }
 
     private static string GetAvaloniaBasePath() =>
@@ -161,6 +162,55 @@ public sealed class EffectorBuildTargetsTests
         path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
             ? path
             : path + Path.DirectorySeparatorChar;
+
+    private static string ResolveRepositoryFile(string[] relativePathSegments, string sourceFilePath)
+    {
+        var relativePath = Path.Combine(relativePathSegments);
+        var attemptedPaths = new List<string>();
+
+        foreach (var repositoryRoot in GetRepositoryRootCandidates(sourceFilePath))
+        {
+            var candidatePath = Path.GetFullPath(Path.Combine(repositoryRoot, relativePath));
+            attemptedPaths.Add(candidatePath);
+
+            if (File.Exists(candidatePath))
+            {
+                return candidatePath;
+            }
+        }
+
+        Assert.Fail(
+            $"Expected file '{relativePath}'. Checked:{Environment.NewLine}{string.Join(Environment.NewLine, attemptedPaths.Distinct(StringComparer.OrdinalIgnoreCase))}");
+        return string.Empty;
+    }
+
+    private static IEnumerable<string> GetRepositoryRootCandidates(string sourceFilePath)
+    {
+        if (!string.IsNullOrWhiteSpace(Directory.GetCurrentDirectory()))
+        {
+            yield return Directory.GetCurrentDirectory();
+        }
+
+        var githubWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        if (!string.IsNullOrWhiteSpace(githubWorkspace))
+        {
+            yield return githubWorkspace!;
+        }
+
+        yield return Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            ".."));
+
+        var testProjectDirectory = Path.GetDirectoryName(sourceFilePath);
+        if (!string.IsNullOrWhiteSpace(testProjectDirectory))
+        {
+            yield return Path.GetFullPath(Path.Combine(testProjectDirectory!, "..", ".."));
+        }
+    }
 
     private readonly record struct ProcessResult(int ExitCode, string Output);
 }

--- a/tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs
+++ b/tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using Avalonia.Media;
+using Effector.Build.Tasks;
+using Xunit;
+
+namespace Effector.Build.Tasks.Tests;
+
+public sealed class EffectorBuildTargetsTests
+{
+    [Fact]
+    public void AndroidBuildTarget_Patches_AvaloniaAssemblies_In_AbiAssetDirectories()
+    {
+        var testRoot = Path.Combine(Path.GetTempPath(), "effector-android-target-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testRoot);
+
+        var intermediateOutputPath = Path.Combine(testRoot, "obj", "Debug", "net9.0-android");
+        var assetsRoot = Path.Combine(intermediateOutputPath, "android", "assets");
+
+        foreach (var abi in new[] { "arm64-v8a", "x86_64" })
+        {
+            var abiDirectory = Path.Combine(assetsRoot, abi);
+            Directory.CreateDirectory(abiDirectory);
+            CopyAvaloniaAssemblyPair(abiDirectory);
+        }
+
+        var scanner = new AvaloniaPatchMetadataScanner();
+        var initialBasePath = Path.Combine(assetsRoot, "arm64-v8a", "Avalonia.Base.dll");
+        var initialSkiaPath = Path.Combine(assetsRoot, "arm64-v8a", "Avalonia.Skia.dll");
+
+        Assert.False(scanner.Scan(initialBasePath, "11.3.12", AvaloniaPatchAssemblyKind.Base).IsAlreadyPatched);
+        Assert.False(scanner.Scan(initialSkiaPath, "11.3.12", AvaloniaPatchAssemblyKind.Skia).IsAlreadyPatched);
+
+        var projectPath = Path.Combine(testRoot, "AndroidPatchHarness.csproj");
+        CreateAndroidPatchHarnessProject(projectPath, intermediateOutputPath);
+
+        var result = RunProcess(
+            "dotnet",
+            new[]
+            {
+                "msbuild",
+                projectPath,
+                "-t:Effector_PatchAvaloniaAndroidAssemblies",
+                "-m:1",
+                "-v:minimal"
+            },
+            testRoot);
+
+        Assert.True(result.ExitCode == 0, result.Output);
+
+        foreach (var abi in new[] { "arm64-v8a", "x86_64" })
+        {
+            var abiDirectory = Path.Combine(assetsRoot, abi);
+            var baseScan = scanner.Scan(Path.Combine(abiDirectory, "Avalonia.Base.dll"), "11.3.12", AvaloniaPatchAssemblyKind.Base);
+            var skiaScan = scanner.Scan(Path.Combine(abiDirectory, "Avalonia.Skia.dll"), "11.3.12", AvaloniaPatchAssemblyKind.Skia);
+
+            Assert.True(baseScan.IsAlreadyPatched, $"Expected Avalonia.Base.dll in '{abiDirectory}' to be patched.{Environment.NewLine}{result.Output}");
+            Assert.True(skiaScan.IsAlreadyPatched, $"Expected Avalonia.Skia.dll in '{abiDirectory}' to be patched.{Environment.NewLine}{result.Output}");
+        }
+    }
+
+    private static void CreateAndroidPatchHarnessProject(string projectPath, string intermediateOutputPath)
+    {
+        var project = new XDocument(
+            new XElement(
+                "Project",
+                new XAttribute("Sdk", "Microsoft.NET.Sdk"),
+                new XElement(
+                    "PropertyGroup",
+                    new XElement("TargetFramework", "net8.0"),
+                    new XElement("Configuration", "Debug"),
+                    new XElement("EffectorEnabled", "true"),
+                    new XElement("AndroidApplication", "true"),
+                    new XElement("IntermediateOutputPath", EnsureTrailingSeparator(intermediateOutputPath)),
+                    new XElement("_EffectorPackagedTaskAssemblyPath", GetBuiltTaskAssemblyPath())),
+                new XElement("Import", new XAttribute("Project", GetBuildTargetsPath()))));
+
+        project.Save(projectPath);
+    }
+
+    private static void CopyAvaloniaAssemblyPair(string destinationDirectory)
+    {
+        File.Copy(GetAvaloniaBasePath(), Path.Combine(destinationDirectory, "Avalonia.Base.dll"), overwrite: true);
+        File.Copy(GetAvaloniaSkiaPath(), Path.Combine(destinationDirectory, "Avalonia.Skia.dll"), overwrite: true);
+    }
+
+    private static ProcessResult RunProcess(string fileName, string[] arguments, string workingDirectory)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo(fileName)
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+        {
+            process.StartInfo.ArgumentList.Add(argument);
+        }
+
+        process.Start();
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return new ProcessResult(process.ExitCode, string.Concat(standardOutput, standardError));
+    }
+
+    private static string GetBuildTargetsPath([CallerFilePath] string sourceFilePath = "")
+    {
+        var testProjectDirectory = Path.GetDirectoryName(sourceFilePath);
+        Assert.False(string.IsNullOrWhiteSpace(testProjectDirectory));
+
+        return Path.GetFullPath(Path.Combine(
+            testProjectDirectory!,
+            "..",
+            "..",
+            "src",
+            "Effector.Build",
+            "buildTransitive",
+            "Effector.Build.targets"));
+    }
+
+    private static string GetBuiltTaskAssemblyPath([CallerFilePath] string sourceFilePath = "")
+    {
+        var testProjectDirectory = Path.GetDirectoryName(sourceFilePath);
+        Assert.False(string.IsNullOrWhiteSpace(testProjectDirectory));
+
+        var configuration =
+            AppContext.BaseDirectory.Contains($"{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                ? "Release"
+                : "Debug";
+
+        var taskAssemblyPath = Path.GetFullPath(Path.Combine(
+            testProjectDirectory!,
+            "..",
+            "..",
+            "src",
+            "Effector.Build.Tasks",
+            "bin",
+            configuration,
+            "netstandard2.0",
+            "Effector.Build.Tasks.dll"));
+
+        Assert.True(File.Exists(taskAssemblyPath), $"Expected built task assembly at '{taskAssemblyPath}'.");
+        return taskAssemblyPath;
+    }
+
+    private static string GetAvaloniaBasePath() =>
+        typeof(Effect).Assembly.Location;
+
+    private static string GetAvaloniaSkiaPath() =>
+        Path.Combine(Path.GetDirectoryName(typeof(Effect).Assembly.Location)!, "Avalonia.Skia.dll");
+
+    private static string EnsureTrailingSeparator(string path) =>
+        path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+
+    private readonly record struct ProcessResult(int ExitCode, string Output);
+}


### PR DESCRIPTION
# PR Summary: Fix Android Avalonia Assembly Patching

## Branch

- `issue-3-android-assembly-patching`

## Issue

- Fixes [issue #3](https://github.com/wieslawsoltes/Effector/issues/3): Android builds packaged unpatched `Avalonia.Base.dll` and `Avalonia.Skia.dll`, causing `InvalidCastException` when a custom Effector effect is used at runtime.

## Problem

Effector already patched Avalonia assemblies in three places:

- build output via `$(TargetDir)`
- publish output via `$(PublishDir)`
- NativeAOT ILC inputs via `@(IlcReference)`

That does not cover the Android packaging pipeline. Android apps package managed assemblies from ABI-specific asset directories under:

`$(IntermediateOutputPath)android/assets/<abi>/`

As a result, the APK could still contain unpatched Avalonia binaries even though the regular output patch target succeeded.

## Root Cause

The packaged `buildTransitive` targets only patched:

- `AfterTargets="CopyFilesToOutputDirectory"`
- `AfterTargets="Publish"`
- `AfterTargets="ComputeIlcCompileInputs"` / `BeforeTargets="WriteIlcRspFileForCompilation"`

There was no Android-specific target after `_PrepareAssemblies`, which is the point where the Android SDK has already copied managed assemblies into the ABI asset directories that `_BuildApkEmbed` later consumes.

## Implementation

### 1. Add Android-aware patch target

Updated `src/Effector.Build/buildTransitive/Effector.Build.targets` to:

- define `_EffectorAndroidAssetsDir` as `$(IntermediateOutputPath)/android/assets`
- add `Effector_PatchAvaloniaAndroidAssemblies`
- run it `AfterTargets="_PrepareAssemblies"` and `BeforeTargets="_BuildApkEmbed"`
- gate it on:
  - `$(EffectorEnabled) == true`
  - not `DesignTimeBuild`
  - `$(AndroidApplication) == true`
  - Android assets directory existing
- glob `$(IntermediateOutputPath)android/assets/*/Avalonia.Base.dll`
- batch per ABI directory and derive the matching `Avalonia.Skia.dll` path
- call `PatchAvaloniaAssembliesTask` for each ABI copy

This makes the APK packaging path consume patched Avalonia assemblies instead of only the desktop-style output directory copies.

### 2. Add regression coverage

Added `tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs` with a functional MSBuild regression test that:

- creates a temporary Android-like directory layout under `obj/Debug/net9.0-android/android/assets/<abi>/`
- copies real `Avalonia.Base.dll` and `Avalonia.Skia.dll` into two ABI folders
- invokes `dotnet msbuild -t:Effector_PatchAvaloniaAndroidAssemblies` against a temporary harness project that imports the packaged target file
- verifies each ABI copy is actually patched using `AvaloniaPatchMetadataScanner`

This is more useful than a string-based XML test because it exercises the real target evaluation and batching logic.

### 3. Update docs

Documentation now states that Effector also patches Android ABI asset copies and the architecture note now reflects the Android and NativeAOT target placements more accurately.

## Commits

1. `b215fea` `Patch Android ABI asset assemblies`
   - adds the Android packaging target
   - adds the functional regression test

2. `beed465` `Document Android assembly patching`
   - updates README
   - updates the design/plan document

## Verification

Ran successfully:

```bash
dotnet test tests/Effector.Build.Tasks.Tests/Effector.Build.Tasks.Tests.csproj -c Debug
```

```bash
dotnet pack src/Effector/Effector.csproj -c Debug -m:1 -p:GeneratePackageOnBuild=false -o artifacts/local-feed
```

```bash
NUGET_PACKAGES=$PWD/artifacts/nuget-packages \
dotnet restore integration/Effector.PackageIntegration.Tests/Effector.PackageIntegration.Tests.csproj \
  --configfile integration/NuGet.config \
  -p:EffectorPackageVersion=0.2.0
```

```bash
NUGET_PACKAGES=$PWD/artifacts/nuget-packages \
AVALONIA_SCREENSHOT_DIR=$PWD/artifacts/integration-screenshots \
DYLD_LIBRARY_PATH=$PWD/integration/Effector.PackageIntegration.Tests/bin/Debug/net8.0/runtimes/osx/native \
dotnet test integration/Effector.PackageIntegration.Tests/Effector.PackageIntegration.Tests.csproj \
  -c Debug \
  --no-restore \
  -p:EffectorPackageVersion=0.2.0
```

## Risk and Scope

- Scope is limited to Android application projects because the new target is gated by `$(AndroidApplication)`.
- Existing desktop, publish, and NativeAOT paths are unchanged.
- I did not run a full device or emulator APK install in this environment; validation here covers the exact ABI asset layout and target execution path that caused the reported issue.
