### PR TITLE
Fix runtime shader default and fallback override on SkiaSharp 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ previewBorder.Effect = new TintEffect
 ## Shader Effects
 
 Runtime shaders use `ISkiaShaderEffectFactory<T>` and `ISkiaShaderEffectValueFactory`. Effector can route the effect through `SKRuntimeEffect` or a fallback renderer depending on runtime capabilities.
+On supported SkiaSharp 3.x runtimes, direct runtime shaders are enabled by default. Set `EFFECTOR_ENABLE_DIRECT_RUNTIME_SHADERS=false` to force the fallback path when needed; fallback renderers are still used automatically when shader compilation fails or the active draw path cannot execute runtime shaders.
 
 ```csharp
 public sealed class ScanlineShaderEffectFactory :

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -23,7 +23,7 @@ public static class EffectorRuntime
     private const string SupportedAvaloniaVersion = "11.3.12";
     private static readonly Version? SkiaSharpAssemblyVersion = typeof(SKRuntimeEffect).Assembly.GetName().Version;
     private static readonly bool IsNativeAot = GetIsNativeAot();
-    private static readonly bool DirectRuntimeShadersOptIn = ParseBooleanEnvironmentVariable("EFFECTOR_ENABLE_DIRECT_RUNTIME_SHADERS");
+    private static readonly bool? DirectRuntimeShadersOverride = ParseOptionalBooleanEnvironmentVariable("EFFECTOR_ENABLE_DIRECT_RUNTIME_SHADERS");
     private static readonly string? ShaderTracePath = Environment.GetEnvironmentVariable("EFFECTOR_SHADER_TRACE_PATH");
     private static readonly string? ShaderSnapshotDir = Environment.GetEnvironmentVariable("EFFECTOR_SHADER_SNAPSHOT_DIR");
 
@@ -161,11 +161,21 @@ public static class EffectorRuntime
         }
     }
 
+    // Effector depends on SkiaSharp 3.x+, so direct runtime shaders should be
+    // enabled by default on supported runtimes. The env var can still force the
+    // path on or off, and fallback renderers still cover shader compilation
+    // failures plus non-compositor-backed draw paths.
     internal static bool DirectRuntimeShadersEnabledByDefault =>
-        (SkiaSharpAssemblyVersion?.Major ?? 0) < 3;
+        SupportsDirectRuntimeShadersByDefault(SkiaSharpAssemblyVersion);
 
     internal static bool DirectRuntimeShadersEnabled =>
-        DirectRuntimeShadersOptIn || DirectRuntimeShadersEnabledByDefault;
+        ResolveDirectRuntimeShadersEnabled(DirectRuntimeShadersOverride, SkiaSharpAssemblyVersion);
+
+    internal static bool SupportsDirectRuntimeShadersByDefault(Version? skiaSharpAssemblyVersion) =>
+        (skiaSharpAssemblyVersion?.Major ?? 0) >= 3;
+
+    internal static bool ResolveDirectRuntimeShadersEnabled(bool? directRuntimeShadersOverride, Version? skiaSharpAssemblyVersion) =>
+        directRuntimeShadersOverride ?? SupportsDirectRuntimeShadersByDefault(skiaSharpAssemblyVersion);
 
     public static void Register(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)]
@@ -2593,19 +2603,30 @@ public static class EffectorRuntime
         return 0.288675f * (float)radius + 0.5f;
     }
 
-    private static bool ParseBooleanEnvironmentVariable(string variableName)
+    private static bool? ParseOptionalBooleanEnvironmentVariable(string variableName)
     {
         var value = Environment.GetEnvironmentVariable(variableName);
         if (string.IsNullOrWhiteSpace(value))
         {
-            return false;
+            return null;
         }
 
         value = value.Trim();
-        return value.Equals("1", StringComparison.Ordinal) ||
-               value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
-               value.Equals("on", StringComparison.OrdinalIgnoreCase) ||
-               bool.TryParse(value, out var enabled) && enabled;
+        if (value.Equals("1", StringComparison.Ordinal) ||
+            value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("on", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (value.Equals("0", StringComparison.Ordinal) ||
+            value.Equals("no", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("off", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return bool.TryParse(value, out var enabled) ? enabled : null;
     }
 
     public static bool IsRegisteredEffect(IEffect? effect) =>

--- a/src/Effector/SkiaRuntimeShaderBuilder.cs
+++ b/src/Effector/SkiaRuntimeShaderBuilder.cs
@@ -32,6 +32,33 @@ public static class SkiaRuntimeShaderBuilder
         SKRect? destinationRect = null,
         SKMatrix? localMatrix = null,
         Action<SKCanvas, SKImage, SKRect>? fallbackRenderer = null)
+        => CreateCore(
+            sksl,
+            context,
+            configureUniforms,
+            configureChildren,
+            contentChildName,
+            isOpaque,
+            blendMode,
+            isAntialias,
+            destinationRect,
+            localMatrix,
+            fallbackRenderer,
+            EffectorRuntime.DirectRuntimeShadersEnabled);
+
+    internal static SkiaShaderEffect CreateCore(
+        string sksl,
+        SkiaShaderEffectContext context,
+        Action<SKRuntimeEffectUniforms>? configureUniforms,
+        Action<SKRuntimeEffectChildren, SkiaShaderEffectContext>? configureChildren,
+        string? contentChildName,
+        bool isOpaque,
+        SKBlendMode blendMode,
+        bool isAntialias,
+        SKRect? destinationRect,
+        SKMatrix? localMatrix,
+        Action<SKCanvas, SKImage, SKRect>? fallbackRenderer,
+        bool directRuntimeShadersEnabled)
     {
         if (string.IsNullOrWhiteSpace(sksl))
         {
@@ -41,7 +68,7 @@ public static class SkiaRuntimeShaderBuilder
         var resolvedDestinationRect = destinationRect ?? context.EffectBounds;
         var resolvedLocalMatrix = localMatrix ?? SKMatrix.CreateTranslation(-resolvedDestinationRect.Left, -resolvedDestinationRect.Top);
 
-        if (!EffectorRuntime.DirectRuntimeShadersEnabled && fallbackRenderer is not null)
+        if (!directRuntimeShadersEnabled && fallbackRenderer is not null)
         {
             return new SkiaShaderEffect(null, blendMode, isAntialias, resolvedDestinationRect, resolvedLocalMatrix, fallbackRenderer);
         }

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -598,16 +598,60 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
-    public void DirectRuntimeShaderPath_IsDisabledByDefault_On_SkiaSharp3()
+    public void DirectRuntimeShaderPath_IsEnabledByDefault_On_Supported_SkiaSharp()
     {
         var skiaVersion = typeof(SKRuntimeEffect).Assembly.GetName().Version;
         Assert.NotNull(skiaVersion);
 
         if (skiaVersion!.Major >= 3)
         {
-            Assert.False(EffectorRuntime.DirectRuntimeShadersEnabledByDefault);
-            Assert.False(EffectorRuntime.DirectRuntimeShadersEnabled);
+            Assert.True(EffectorRuntime.DirectRuntimeShadersEnabledByDefault);
+            Assert.True(EffectorRuntime.DirectRuntimeShadersEnabled);
         }
+    }
+
+    [Fact]
+    public void DirectRuntimeShaderOverride_Can_Enable_And_Disable_RuntimeShaderPath()
+    {
+        Assert.True(EffectorRuntime.ResolveDirectRuntimeShadersEnabled(directRuntimeShadersOverride: null, new Version(3, 119, 2)));
+        Assert.False(EffectorRuntime.ResolveDirectRuntimeShadersEnabled(directRuntimeShadersOverride: false, new Version(3, 119, 2)));
+        Assert.False(EffectorRuntime.ResolveDirectRuntimeShadersEnabled(directRuntimeShadersOverride: null, new Version(2, 88, 0)));
+        Assert.True(EffectorRuntime.ResolveDirectRuntimeShadersEnabled(directRuntimeShadersOverride: true, new Version(2, 88, 0)));
+    }
+
+    [Fact]
+    public void ShaderBuilder_Creates_RuntimeShader_When_DirectRuntimeShaders_Are_Enabled_Even_With_Fallback()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(64, 48));
+        Assert.NotNull(surface);
+        using var snapshot = surface!.Snapshot();
+        var context = new SkiaShaderEffectContext(
+            new SkiaEffectContext(1d, usesOpacitySaveLayer: false),
+            snapshot,
+            new SKRect(0, 0, 64, 48),
+            new SKRect(0, 0, 64, 48));
+
+        using var shaderEffect = SkiaRuntimeShaderBuilder.CreateCore(
+            "half4 main(float2 coord) { return half4(1.0, 0.0, 0.0, 1.0); }",
+            context,
+            configureUniforms: null,
+            configureChildren: null,
+            contentChildName: null,
+            isOpaque: false,
+            blendMode: SKBlendMode.SrcOver,
+            isAntialias: true,
+            destinationRect: null,
+            localMatrix: null,
+            fallbackRenderer: static (canvas, _, rect) =>
+            {
+                using var paint = new SKPaint { Color = SKColors.Red };
+                canvas.DrawRect(rect, paint);
+            },
+            directRuntimeShadersEnabled: true);
+
+        Assert.NotNull(shaderEffect);
+        Assert.NotNull(shaderEffect.Shader);
+        Assert.NotNull(shaderEffect.FallbackRenderer);
     }
 
     [Fact]
@@ -627,11 +671,6 @@ public sealed class EffectorRuntimeBehaviorTests
     [Fact]
     public void ShaderBuilder_Uses_Fallback_When_DirectRuntimeShaders_Are_Disabled()
     {
-        if (EffectorRuntime.DirectRuntimeShadersEnabled)
-        {
-            return;
-        }
-
         using var surface = SKSurface.Create(new SKImageInfo(64, 48));
         Assert.NotNull(surface);
         using var snapshot = surface!.Snapshot();
@@ -641,14 +680,23 @@ public sealed class EffectorRuntimeBehaviorTests
             new SKRect(0, 0, 64, 48),
             new SKRect(0, 0, 64, 48));
 
-        using var shaderEffect = SkiaRuntimeShaderBuilder.Create(
+        using var shaderEffect = SkiaRuntimeShaderBuilder.CreateCore(
             "half4 main(float2 coord) { return half4(1.0, 0.0, 0.0, 1.0); }",
             context,
+            configureUniforms: null,
+            configureChildren: null,
+            contentChildName: null,
+            isOpaque: false,
+            blendMode: SKBlendMode.SrcOver,
+            isAntialias: true,
+            destinationRect: null,
+            localMatrix: null,
             fallbackRenderer: static (canvas, _, rect) =>
             {
                 using var paint = new SKPaint { Color = SKColors.Red };
                 canvas.DrawRect(rect, paint);
-            });
+            },
+            directRuntimeShadersEnabled: false);
 
         Assert.NotNull(shaderEffect);
         Assert.Null(shaderEffect.Shader);


### PR DESCRIPTION
# PR Summary: Fix runtime shader default for SkiaSharp 3.x

## Overview

This branch fixes issue [#4](https://github.com/wieslawsoltes/Effector/issues/4), where Effector disabled direct runtime SkSL shaders by default even though the package already depends on `SkiaSharp 3.119.2`.

Before this change, any effect created through `SkiaRuntimeShaderBuilder.Create(...)` with a `fallbackRenderer` would usually return the fallback-only path immediately because `EffectorRuntime.DirectRuntimeShadersEnabled` evaluated to `false` by default on SkiaSharp 3.x. In practice, that made the GPU shader path dead code for the supported runtime.

## Root Cause

The default runtime-shader gate in `EffectorRuntime` used this heuristic:

```csharp
internal static bool DirectRuntimeShadersEnabledByDefault =>
    (SkiaSharpAssemblyVersion?.Major ?? 0) < 3;
```

That condition is inverted for this package's dependency floor. Since Effector ships against SkiaSharp 3.x, the expression always evaluates to `false` on supported runtimes.

The builder then short-circuited before compiling the runtime shader whenever a fallback renderer was present:

```csharp
if (!EffectorRuntime.DirectRuntimeShadersEnabled && fallbackRenderer is not null)
{
    return new SkiaShaderEffect(null, ... fallbackRenderer);
}
```

## What Changed

### 1. Runtime shader default now matches the supported dependency range

`EffectorRuntime` now treats SkiaSharp 3.x and later as supporting direct runtime shaders by default.

### 2. Environment-variable behavior now supports explicit enable and disable

The existing `EFFECTOR_ENABLE_DIRECT_RUNTIME_SHADERS` environment variable is now parsed as an explicit nullable override rather than an enable-only flag.

Behavior is now:

- unset: use the runtime default
- `true` / `1` / `yes` / `on`: force-enable direct runtime shaders
- `false` / `0` / `no` / `off`: force-disable direct runtime shaders

This preserves the issue fix while keeping a reliable escape hatch for environments where the fallback path is still preferable.

### 3. Shader-builder tests are deterministic

The shader-builder tests previously depended on the machine's runtime setting and had to skip one branch or the other. The branch now exposes a small internal `CreateCore(...)` path so the enabled and disabled builder behaviors can be asserted directly in tests without depending on host-specific runtime conditions.

### 4. Documentation was updated

The README now explicitly states that:

- direct runtime shaders are enabled by default on supported SkiaSharp 3.x runtimes
- `EFFECTOR_ENABLE_DIRECT_RUNTIME_SHADERS=false` forces the fallback path when needed

## Commit Breakdown

### Commit 1

`c1101a7`  
`Fix runtime shader default and override handling`

Includes:

- correcting the runtime-shader default for SkiaSharp 3.x
- introducing explicit env-var override semantics
- adding deterministic test coverage for:
  - the supported-runtime default
  - explicit enable/disable override resolution
  - builder behavior with runtime shaders forced on
  - builder behavior with runtime shaders forced off

### Commit 2

`8d79019`  
`Document runtime shader fallback override`

Includes:

- README clarification for default runtime-shader behavior
- README documentation for forcing the fallback path with the environment variable

## Files Changed

### Runtime behavior

- `src/Effector/EffectorRuntime.cs`
- `src/Effector/SkiaRuntimeShaderBuilder.cs`

### Test coverage

- `tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs`

### Documentation

- `README.md`

## Validation

The following commands were run successfully:

```bash
dotnet test tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj --verbosity minimal
dotnet test Effector.slnx --verbosity minimal
```

Observed pre-existing non-blocking warnings:

- `CS8602` nullable warning in `src/Effector/EffectorRuntime.cs`
- `NU5128` package-layout warnings during pack

These warnings were present during verification but are not introduced by this branch.

## User-Facing Impact

After this change:

- runtime shader effects on supported SkiaSharp 3.x runtimes will use the direct shader path by default
- effects that provide a `fallbackRenderer` no longer suppress runtime shader compilation just by existing
- consumers can still opt out and force the fallback path explicitly through `EFFECTOR_ENABLE_DIRECT_RUNTIME_SHADERS=false`

## Risk Assessment

Risk is low and localized:

- the public `SkiaRuntimeShaderBuilder.Create(...)` API remains unchanged
- the fallback path is still used automatically when shader compilation fails or the active draw path cannot execute runtime shaders
- the env-var override makes the behavior safer to deploy because consumers retain an explicit off switch

## Suggested PR Title

Fix runtime shader default and fallback override on SkiaSharp 3.x

## Suggested PR Description

Fixes #4.

Effector was disabling direct runtime shaders by default on SkiaSharp 3.x because the default heuristic was inverted relative to the package's own dependency floor. As a result, effects built with `SkiaRuntimeShaderBuilder.Create(...)` and a `fallbackRenderer` would often skip shader compilation entirely and run only the fallback path.

This PR:

- enables direct runtime shaders by default on supported SkiaSharp 3.x runtimes
- preserves an explicit off switch through `EFFECTOR_ENABLE_DIRECT_RUNTIME_SHADERS=false`
- adds deterministic regression coverage for both enabled and disabled builder paths
- updates the README to describe the corrected behavior
