### PR TITLE
Fix shader anchor drift when RenderTransform is active

### DIFF
--- a/samples/Effector.Sample.Effects/InteractiveShaderEffects.cs
+++ b/samples/Effector.Sample.Effects/InteractiveShaderEffects.cs
@@ -205,7 +205,8 @@ public sealed class PointerSpotlightShaderEffectFactory :
             float active = max(hover, pressed);
             float intensity = min((strength * active) + (pressBoost * pressed), 1.0);
             float alpha = spot * spot * intensity;
-            return half4(red, green, blue, alpha);
+            half premulAlpha = half(alpha);
+            return half4(red * premulAlpha, green * premulAlpha, blue * premulAlpha, premulAlpha);
         }
         """;
 
@@ -482,7 +483,8 @@ public sealed class ReactiveGridShaderEffectFactory :
             float active = max(hover, pressed);
             float alpha = (baseGrid * (strength * 0.45)) + (halo * active * (0.18 + (pressBoost * pressed)));
             alpha = min(alpha, 1.0);
-            return half4(red, green, blue, alpha);
+            half premulAlpha = half(alpha);
+            return half4(red * premulAlpha, green * premulAlpha, blue * premulAlpha, premulAlpha);
         }
         """;
 

--- a/samples/Effector.Sample.Effects/ShaderEffects.cs
+++ b/samples/Effector.Sample.Effects/ShaderEffects.cs
@@ -153,7 +153,8 @@ public sealed class GridShaderEffectFactory :
             float gx = fract(coord.x / span);
             float gy = fract(coord.y / span);
             float alpha = (gx < 0.06 || gy < 0.06) ? strength : 0.0;
-            return half4(red, green, blue, alpha);
+            half premulAlpha = half(alpha);
+            return half4(red * premulAlpha, green * premulAlpha, blue * premulAlpha, premulAlpha);
         }
         """;
 
@@ -293,7 +294,8 @@ public sealed class SpotlightShaderEffectFactory :
             float dist = sqrt((dx * dx) + (dy * dy));
             float fade = dist >= radius ? 0.0 : 1.0 - (dist / max(radius, 0.001));
             float alpha = fade * strength;
-            return half4(red, green, blue, alpha);
+            half premulAlpha = half(alpha);
+            return half4(red * premulAlpha, green * premulAlpha, blue * premulAlpha, premulAlpha);
         }
         """;
 

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -1503,11 +1503,13 @@ public static class EffectorRuntime
         var deviceClip = ToSKRect(deviceClipBounds);
         var usedHostVisualBounds = TryGetHostVisualBounds(effect, out var hostBounds);
         var usedRenderThreadBounds = TakeRenderThreadEffectBounds(effect, out var renderBounds);
+        var preferHostBounds = ShouldPreferHostBounds(effect, out var unclippedHostSize);
         var authoritativeEffectRect = SelectAuthoritativeEffectRectCandidateWithHostPreference(
             effectClipRect,
             usedHostVisualBounds ? hostBounds : (Rect?)null,
             usedRenderThreadBounds ? renderBounds : (Rect?)null,
-            ShouldPreferHostBounds(effect));
+            preferHostBounds,
+            unclippedHostSize);
         var intermediateSurfaceDpi = s_skiaIntermediateSurfaceDpiField?.GetValue(drawingContext) is Vector vector
             ? vector
             : new Vector(96d, 96d);
@@ -2060,17 +2062,23 @@ public static class EffectorRuntime
     private static Rect? SelectAuthoritativeEffectRect(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds) =>
         SelectAuthoritativeEffectRectCandidate(effectClipRect, hostBounds, renderBounds).Rect;
 
-    private static Rect? SelectAuthoritativeEffectRectForHostPreference(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds, bool preferHostBounds) =>
-        SelectAuthoritativeEffectRectCandidateWithHostPreference(effectClipRect, hostBounds, renderBounds, preferHostBounds).Rect;
+    private static Rect? SelectAuthoritativeEffectRectForHostPreference(
+        Rect? effectClipRect,
+        Rect? hostBounds,
+        Rect? renderBounds,
+        bool preferHostBounds,
+        Size? unclippedHostSize = null) =>
+        SelectAuthoritativeEffectRectCandidateWithHostPreference(effectClipRect, hostBounds, renderBounds, preferHostBounds, unclippedHostSize).Rect;
 
     private static SelectedEffectRect SelectAuthoritativeEffectRectCandidate(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds) =>
-        SelectAuthoritativeEffectRectCandidateWithHostPreference(effectClipRect, hostBounds, renderBounds, preferHostBounds: false);
+        SelectAuthoritativeEffectRectCandidateWithHostPreference(effectClipRect, hostBounds, renderBounds, preferHostBounds: false, unclippedHostSize: null);
 
     private static SelectedEffectRect SelectAuthoritativeEffectRectCandidateWithHostPreference(
         Rect? effectClipRect,
         Rect? hostBounds,
         Rect? renderBounds,
-        bool preferHostBounds)
+        bool preferHostBounds,
+        Size? unclippedHostSize)
     {
         if (TrySelectTightHostBounds(effectClipRect, hostBounds, renderBounds, out var tightHostBounds))
         {
@@ -2079,7 +2087,13 @@ public static class EffectorRuntime
 
         if (preferHostBounds && hostBounds.HasValue && hostBounds.Value.Width > 0d && hostBounds.Value.Height > 0d)
         {
-            return new SelectedEffectRect(hostBounds, EffectRectSource.HostLogical);
+            var preferredHostBounds = hostBounds.Value;
+            if (TryClipPreferredHostBounds(effectClipRect, preferredHostBounds, unclippedHostSize, out var clippedHostBounds))
+            {
+                return new SelectedEffectRect(clippedHostBounds, EffectRectSource.HostLogical);
+            }
+
+            return new SelectedEffectRect(preferredHostBounds, EffectRectSource.HostLogical);
         }
 
         if (effectClipRect.HasValue && effectClipRect.Value.Width > 0d && effectClipRect.Value.Height > 0d)
@@ -2100,15 +2114,59 @@ public static class EffectorRuntime
         return default;
     }
 
-    private static bool ShouldPreferHostBounds(IEffect effect)
+    private static bool ShouldPreferHostBounds(IEffect effect, out Size? unclippedHostSize)
     {
+        unclippedHostSize = null;
         if (!TryGetHostVisual(effect, out var visual))
         {
             return false;
         }
 
         var renderTransform = visual.RenderTransform;
-        return renderTransform is not null && !renderTransform.Value.IsIdentity;
+        if (renderTransform is null || renderTransform.Value.IsIdentity)
+        {
+            return false;
+        }
+
+        var width = visual.Bounds.Width;
+        var height = visual.Bounds.Height;
+        if (width > 0d && height > 0d)
+        {
+            if (TryGetPadding(effect, out var padding))
+            {
+                width += padding.Left + padding.Right;
+                height += padding.Top + padding.Bottom;
+            }
+
+            unclippedHostSize = new Size(width, height);
+        }
+
+        return true;
+    }
+
+    private static bool TryClipPreferredHostBounds(Rect? effectClipRect, Rect preferredHostBounds, Size? unclippedHostSize, out Rect clippedBounds)
+    {
+        const double tolerance = 2d;
+
+        if (!effectClipRect.HasValue || effectClipRect.Value.Width <= 0d || effectClipRect.Value.Height <= 0d || !unclippedHostSize.HasValue)
+        {
+            clippedBounds = default;
+            return false;
+        }
+
+        var clip = effectClipRect.Value;
+        var hostSize = unclippedHostSize.Value;
+        var materiallyClipped =
+            clip.Width < (hostSize.Width - tolerance) ||
+            clip.Height < (hostSize.Height - tolerance);
+        if (!materiallyClipped)
+        {
+            clippedBounds = default;
+            return false;
+        }
+
+        clippedBounds = preferredHostBounds.Intersect(clip);
+        return clippedBounds.Width > 0d && clippedBounds.Height > 0d;
     }
 
     private static bool TrySelectTightHostBounds(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds, out Rect bounds)

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -34,6 +34,7 @@ public static class EffectorRuntime
     private static readonly Dictionary<Type, EffectorShaderDebugInfo> ShaderDebugInfoByType = new();
     private static readonly ConditionalWeakTable<object, HostVisualHolder> HostVisuals = new();
     private static readonly ConditionalWeakTable<IEffect, EffectBoundsHolder> HostVisualBounds = new();
+    private static readonly ConditionalWeakTable<IEffect, HostPreferenceHolder> HostVisualPreferences = new();
     private static readonly ConditionalWeakTable<IEffect, EffectBoundsHolder> RenderThreadEffectBounds = new();
     private static readonly ConditionalWeakTable<IEffect, ProxyHolder> RenderThreadProxies = new();
     private static readonly ConditionalWeakTable<IEffect, ProxyHolder> RenderThreadVisuals = new();
@@ -80,6 +81,19 @@ public static class EffectorRuntime
         }
 
         public Visual Visual { get; }
+    }
+
+    private sealed class HostPreferenceHolder
+    {
+        public HostPreferenceHolder(bool preferHostBounds, Size? unclippedHostSize)
+        {
+            PreferHostBounds = preferHostBounds;
+            UnclippedHostSize = unclippedHostSize;
+        }
+
+        public bool PreferHostBounds { get; }
+
+        public Size? UnclippedHostSize { get; }
     }
 
     private sealed class MirroredEffectHolder
@@ -780,6 +794,9 @@ public static class EffectorRuntime
         }
 
         PropagateMirroredHostVisual(avaloniaEffect, visual);
+        var (preferHostBounds, unclippedHostSize) = ResolveHostVisualPreference(avaloniaEffect, visual);
+        StoreHostVisualPreference(avaloniaEffect, preferHostBounds, unclippedHostSize);
+        PropagateMirroredHostVisualPreference(avaloniaEffect, preferHostBounds, unclippedHostSize);
 
         if (TryResolveHostVisualBounds(avaloniaEffect, visual, out var bounds))
         {
@@ -802,6 +819,7 @@ public static class EffectorRuntime
             if (effect is IEffect avaloniaEffect)
             {
                 HostVisualBounds.Remove(avaloniaEffect);
+                HostVisualPreferences.Remove(avaloniaEffect);
                 ClearMirroredHostVisual(avaloniaEffect);
             }
         }
@@ -823,6 +841,11 @@ public static class EffectorRuntime
             if (HostVisualBounds.TryGetValue(source, out var boundsHolder))
             {
                 StoreHostVisualBounds(mirror, boundsHolder.Bounds);
+            }
+
+            if (HostVisualPreferences.TryGetValue(source, out var preferenceHolder))
+            {
+                StoreHostVisualPreference(mirror, preferenceHolder.PreferHostBounds, preferenceHolder.UnclippedHostSize);
             }
         }
     }
@@ -854,6 +877,19 @@ public static class EffectorRuntime
         }
     }
 
+    private static void PropagateMirroredHostVisualPreference(IEffect source, bool preferHostBounds, Size? unclippedHostSize)
+    {
+        lock (Sync)
+        {
+            if (!MirroredEffects.TryGetValue(source, out var mirror))
+            {
+                return;
+            }
+
+            StoreHostVisualPreference(mirror.Effect, preferHostBounds, unclippedHostSize);
+        }
+    }
+
     private static void ClearMirroredHostVisual(IEffect source)
     {
         lock (Sync)
@@ -865,6 +901,7 @@ public static class EffectorRuntime
 
             HostVisuals.Remove(mirror.Effect);
             HostVisualBounds.Remove(mirror.Effect);
+            HostVisualPreferences.Remove(mirror.Effect);
         }
     }
 
@@ -1010,6 +1047,15 @@ public static class EffectorRuntime
         }
     }
 
+    private static void StoreHostVisualPreference(IEffect effect, bool preferHostBounds, Size? unclippedHostSize)
+    {
+        lock (Sync)
+        {
+            HostVisualPreferences.Remove(effect);
+            HostVisualPreferences.Add(effect, new HostPreferenceHolder(preferHostBounds, unclippedHostSize));
+        }
+    }
+
     private static bool TryGetHostVisualBounds(IEffect effect, out Rect bounds)
     {
         lock (Sync)
@@ -1025,18 +1071,20 @@ public static class EffectorRuntime
         return false;
     }
 
-    private static bool TryGetHostVisual(IEffect effect, out Visual visual)
+    private static bool TryGetHostVisualPreference(IEffect effect, out bool preferHostBounds, out Size? unclippedHostSize)
     {
         lock (Sync)
         {
-            if (HostVisuals.TryGetValue(effect, out var holder))
+            if (HostVisualPreferences.TryGetValue(effect, out var holder))
             {
-                visual = holder.Visual;
+                preferHostBounds = holder.PreferHostBounds;
+                unclippedHostSize = holder.UnclippedHostSize;
                 return true;
             }
         }
 
-        visual = null!;
+        preferHostBounds = false;
+        unclippedHostSize = null;
         return false;
     }
 
@@ -1126,6 +1174,27 @@ public static class EffectorRuntime
             HostVisualBounds.Remove(effect);
             HostVisualBounds.Add(effect, new EffectBoundsHolder(bounds));
         }
+    }
+
+    private static (bool PreferHostBounds, Size? UnclippedHostSize) ResolveHostVisualPreference(IEffect effect, Visual visual)
+    {
+        var renderTransform = visual.RenderTransform;
+        var preferHostBounds = renderTransform is not null && !renderTransform.Value.IsIdentity;
+
+        var width = visual.Bounds.Width;
+        var height = visual.Bounds.Height;
+        if (width <= 0d || height <= 0d)
+        {
+            return (preferHostBounds, null);
+        }
+
+        if (TryGetPadding(effect, out var padding))
+        {
+            width += padding.Left + padding.Right;
+            height += padding.Top + padding.Bottom;
+        }
+
+        return (preferHostBounds, new Size(width, height));
     }
 
     public static object CreateFactory(
@@ -2116,32 +2185,7 @@ public static class EffectorRuntime
 
     private static bool ShouldPreferHostBounds(IEffect effect, out Size? unclippedHostSize)
     {
-        unclippedHostSize = null;
-        if (!TryGetHostVisual(effect, out var visual))
-        {
-            return false;
-        }
-
-        var renderTransform = visual.RenderTransform;
-        if (renderTransform is null || renderTransform.Value.IsIdentity)
-        {
-            return false;
-        }
-
-        var width = visual.Bounds.Width;
-        var height = visual.Bounds.Height;
-        if (width > 0d && height > 0d)
-        {
-            if (TryGetPadding(effect, out var padding))
-            {
-                width += padding.Left + padding.Right;
-                height += padding.Top + padding.Bottom;
-            }
-
-            unclippedHostSize = new Size(width, height);
-        }
-
-        return true;
+        return TryGetHostVisualPreference(effect, out var preferHostBounds, out unclippedHostSize) && preferHostBounds;
     }
 
     private static bool TryClipPreferredHostBounds(Rect? effectClipRect, Rect preferredHostBounds, Size? unclippedHostSize, out Rect clippedBounds)

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -2190,7 +2190,8 @@ public static class EffectorRuntime
 
     private static bool TryClipPreferredHostBounds(Rect? effectClipRect, Rect preferredHostBounds, Size? unclippedHostSize, out Rect clippedBounds)
     {
-        const double tolerance = 2d;
+        const double sizeTolerance = 2d;
+        const double centerTolerance = 2d;
 
         if (!effectClipRect.HasValue || effectClipRect.Value.Width <= 0d || effectClipRect.Value.Height <= 0d || !unclippedHostSize.HasValue)
         {
@@ -2199,11 +2200,16 @@ public static class EffectorRuntime
         }
 
         var clip = effectClipRect.Value;
-        var hostSize = unclippedHostSize.Value;
         var materiallyClipped =
-            clip.Width < (hostSize.Width - tolerance) ||
-            clip.Height < (hostSize.Height - tolerance);
+            clip.Width < (preferredHostBounds.Width - sizeTolerance) ||
+            clip.Height < (preferredHostBounds.Height - sizeTolerance);
         if (!materiallyClipped)
+        {
+            clippedBounds = default;
+            return false;
+        }
+
+        if (IsLikelyStalePreTransformClip(clip, preferredHostBounds, unclippedHostSize.Value, sizeTolerance, centerTolerance))
         {
             clippedBounds = default;
             return false;
@@ -2211,6 +2217,28 @@ public static class EffectorRuntime
 
         clippedBounds = preferredHostBounds.Intersect(clip);
         return clippedBounds.Width > 0d && clippedBounds.Height > 0d;
+    }
+
+    private static bool IsLikelyStalePreTransformClip(
+        Rect clip,
+        Rect preferredHostBounds,
+        Size unclippedHostSize,
+        double sizeTolerance,
+        double centerTolerance)
+    {
+        var matchesUnclippedSize =
+            Math.Abs(clip.Width - unclippedHostSize.Width) <= sizeTolerance &&
+            Math.Abs(clip.Height - unclippedHostSize.Height) <= sizeTolerance;
+        if (!matchesUnclippedSize || !RectContains(preferredHostBounds, clip, sizeTolerance))
+        {
+            return false;
+        }
+
+        var clipCenter = clip.Center;
+        var preferredCenter = preferredHostBounds.Center;
+        return
+            Math.Abs(clipCenter.X - preferredCenter.X) <= centerTolerance &&
+            Math.Abs(clipCenter.Y - preferredCenter.Y) <= centerTolerance;
     }
 
     private static bool TrySelectTightHostBounds(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds, out Rect bounds)

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -1025,6 +1025,21 @@ public static class EffectorRuntime
         return false;
     }
 
+    private static bool TryGetHostVisual(IEffect effect, out Visual visual)
+    {
+        lock (Sync)
+        {
+            if (HostVisuals.TryGetValue(effect, out var holder))
+            {
+                visual = holder.Visual;
+                return true;
+            }
+        }
+
+        visual = null!;
+        return false;
+    }
+
     private static bool TryResolveCurrentHostVisualBounds(IEffect effect, out Rect bounds)
     {
         lock (Sync)
@@ -1488,10 +1503,11 @@ public static class EffectorRuntime
         var deviceClip = ToSKRect(deviceClipBounds);
         var usedHostVisualBounds = TryGetHostVisualBounds(effect, out var hostBounds);
         var usedRenderThreadBounds = TakeRenderThreadEffectBounds(effect, out var renderBounds);
-        var authoritativeEffectRect = SelectAuthoritativeEffectRectCandidate(
+        var authoritativeEffectRect = SelectAuthoritativeEffectRectCandidateWithHostPreference(
             effectClipRect,
             usedHostVisualBounds ? hostBounds : (Rect?)null,
-            usedRenderThreadBounds ? renderBounds : (Rect?)null);
+            usedRenderThreadBounds ? renderBounds : (Rect?)null,
+            ShouldPreferHostBounds(effect));
         var intermediateSurfaceDpi = s_skiaIntermediateSurfaceDpiField?.GetValue(drawingContext) is Vector vector
             ? vector
             : new Vector(96d, 96d);
@@ -2044,11 +2060,26 @@ public static class EffectorRuntime
     private static Rect? SelectAuthoritativeEffectRect(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds) =>
         SelectAuthoritativeEffectRectCandidate(effectClipRect, hostBounds, renderBounds).Rect;
 
-    private static SelectedEffectRect SelectAuthoritativeEffectRectCandidate(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds)
+    private static Rect? SelectAuthoritativeEffectRectForHostPreference(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds, bool preferHostBounds) =>
+        SelectAuthoritativeEffectRectCandidateWithHostPreference(effectClipRect, hostBounds, renderBounds, preferHostBounds).Rect;
+
+    private static SelectedEffectRect SelectAuthoritativeEffectRectCandidate(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds) =>
+        SelectAuthoritativeEffectRectCandidateWithHostPreference(effectClipRect, hostBounds, renderBounds, preferHostBounds: false);
+
+    private static SelectedEffectRect SelectAuthoritativeEffectRectCandidateWithHostPreference(
+        Rect? effectClipRect,
+        Rect? hostBounds,
+        Rect? renderBounds,
+        bool preferHostBounds)
     {
         if (TrySelectTightHostBounds(effectClipRect, hostBounds, renderBounds, out var tightHostBounds))
         {
             return new SelectedEffectRect(tightHostBounds, EffectRectSource.HostLogical);
+        }
+
+        if (preferHostBounds && hostBounds.HasValue && hostBounds.Value.Width > 0d && hostBounds.Value.Height > 0d)
+        {
+            return new SelectedEffectRect(hostBounds, EffectRectSource.HostLogical);
         }
 
         if (effectClipRect.HasValue && effectClipRect.Value.Width > 0d && effectClipRect.Value.Height > 0d)
@@ -2067,6 +2098,17 @@ public static class EffectorRuntime
         }
 
         return default;
+    }
+
+    private static bool ShouldPreferHostBounds(IEffect effect)
+    {
+        if (!TryGetHostVisual(effect, out var visual))
+        {
+            return false;
+        }
+
+        var renderTransform = visual.RenderTransform;
+        return renderTransform is not null && !renderTransform.Value.IsIdentity;
     }
 
     private static bool TrySelectTightHostBounds(Rect? effectClipRect, Rect? hostBounds, Rect? renderBounds, out Rect bounds)

--- a/src/Effector/SkiaEffectInputManager.cs
+++ b/src/Effector/SkiaEffectInputManager.cs
@@ -72,7 +72,9 @@ internal static class SkiaEffectInputManager
         private readonly SkiaEffectHostContext _context;
         private readonly IDisposable _boundsSubscription;
         private readonly IDisposable _renderTransformSubscription;
+        private readonly IDisposable _renderTransformOriginSubscription;
         private readonly Layoutable? _layoutable;
+        private Transform? _observedRenderTransform;
         private bool _disposed;
 
         public SkiaEffectInputAttachment(Visual visual, SkiaEffectBase effect, ISkiaInputEffectHandler? handler)
@@ -84,8 +86,11 @@ internal static class SkiaEffectInputManager
             _boundsSubscription = visual.GetObservable(Visual.BoundsProperty)
                 .Subscribe(new AnonymousObserver<Rect>(_ => OnBoundsChanged()));
             _renderTransformSubscription = visual.GetObservable(Visual.RenderTransformProperty)
-                .Subscribe(new AnonymousObserver<ITransform?>(_ => OnBoundsChanged()));
+                .Subscribe(new AnonymousObserver<ITransform?>(OnRenderTransformChanged));
+            _renderTransformOriginSubscription = visual.GetObservable(Visual.RenderTransformOriginProperty)
+                .Subscribe(new AnonymousObserver<RelativePoint>(_ => OnBoundsChanged()));
             _layoutable = visual as Layoutable;
+            AttachRenderTransformObserver(visual.RenderTransform);
             if (_layoutable is not null)
             {
                 _layoutable.LayoutUpdated += LayoutUpdated;
@@ -120,6 +125,8 @@ internal static class SkiaEffectInputManager
             _disposed = true;
             _boundsSubscription.Dispose();
             _renderTransformSubscription.Dispose();
+            _renderTransformOriginSubscription.Dispose();
+            DetachRenderTransformObserver();
             if (_layoutable is not null)
             {
                 _layoutable.LayoutUpdated -= LayoutUpdated;
@@ -197,6 +204,17 @@ internal static class SkiaEffectInputManager
             }
         }
 
+        private void OnRenderTransformChanged(ITransform? transform)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            AttachRenderTransformObserver(transform);
+            OnBoundsChanged();
+        }
+
         private void OnBoundsChanged()
         {
             if (_disposed)
@@ -211,5 +229,34 @@ internal static class SkiaEffectInputManager
         private void LayoutUpdated(object? sender, EventArgs e) => OnBoundsChanged();
 
         private void EffectiveViewportChanged(object? sender, EffectiveViewportChangedEventArgs e) => OnBoundsChanged();
+
+        private void AttachRenderTransformObserver(ITransform? transform)
+        {
+            var observedTransform = transform as Transform;
+            if (ReferenceEquals(_observedRenderTransform, observedTransform))
+            {
+                return;
+            }
+
+            DetachRenderTransformObserver();
+            _observedRenderTransform = observedTransform;
+            if (_observedRenderTransform is not null)
+            {
+                _observedRenderTransform.Changed += RenderTransformChanged;
+            }
+        }
+
+        private void DetachRenderTransformObserver()
+        {
+            if (_observedRenderTransform is null)
+            {
+                return;
+            }
+
+            _observedRenderTransform.Changed -= RenderTransformChanged;
+            _observedRenderTransform = null;
+        }
+
+        private void RenderTransformChanged(object? sender, EventArgs e) => OnBoundsChanged();
     }
 }

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -163,6 +163,64 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public void HostBounds_Update_When_RenderTransform_Mutates_InPlace()
+    {
+        RunOnUiThread(() =>
+        {
+            var effect = new GridShaderEffect
+            {
+                CellSize = 16d,
+                Strength = 0.4d,
+                Color = Color.Parse("#00D9FF")
+            };
+
+            var scale = new ScaleTransform(1d, 1d);
+            var host = new Border
+            {
+                Width = 120,
+                Height = 80,
+                Effect = effect,
+                RenderTransform = scale,
+                RenderTransformOrigin = RelativePoint.Center
+            };
+
+            var canvas = new Canvas
+            {
+                Width = 320,
+                Height = 220,
+                Children = { host }
+            };
+
+            var window = new Window
+            {
+                Width = 320,
+                Height = 220,
+                Content = canvas
+            };
+
+            Canvas.SetLeft(host, 48d);
+            Canvas.SetTop(host, 36d);
+            window.Show();
+            window.UpdateLayout();
+
+            var initialBounds = GetStoredHostBounds(effect);
+
+            scale.ScaleX = 1.4d;
+            scale.ScaleY = 1.25d;
+
+            var updatedBounds = GetStoredHostBounds(effect);
+            var expectedBounds = GetVisualBoundsRelativeTo(host, window);
+
+            Assert.True(updatedBounds.Width > initialBounds.Width + 20d);
+            Assert.True(updatedBounds.Height > initialBounds.Height + 10d);
+            Assert.True(Math.Abs(updatedBounds.X - expectedBounds.X) <= 2d);
+            Assert.True(Math.Abs(updatedBounds.Y - expectedBounds.Y) <= 2d);
+            Assert.True(Math.Abs(updatedBounds.Width - expectedBounds.Width) <= 2d);
+            Assert.True(Math.Abs(updatedBounds.Height - expectedBounds.Height) <= 2d);
+        });
+    }
+
+    [Fact]
     public void GetEffectOutputPadding_UsesCustomFactory_ForGlowEffect()
     {
         RunOnUiThread(() =>
@@ -425,6 +483,21 @@ public sealed class EffectorRuntimeBehaviorTests
         var selected = (Rect?)selectMethod.Invoke(null, new object?[] { null, staleHostBounds, renderThreadBounds });
 
         Assert.Equal(staleHostBounds, selected);
+    }
+
+    [Fact]
+    public void ShaderBoundsSelection_Prefers_TransformedHostBounds_Over_ClipRect()
+    {
+        var selectMethod = typeof(EffectorRuntime).GetMethod(
+            "SelectAuthoritativeEffectRectForHostPreference",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        var staleClipRect = new Rect(48d, 36d, 120d, 80d);
+        var transformedHostBounds = new Rect(24d, 26d, 168d, 100d);
+
+        var selected = (Rect?)selectMethod.Invoke(null, new object?[] { staleClipRect, transformedHostBounds, null, true });
+
+        Assert.Equal(transformedHostBounds, selected);
     }
 
     [Fact]
@@ -2065,6 +2138,37 @@ public sealed class EffectorRuntimeBehaviorTests
         var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         Assert.NotNull(property);
         return (T)property!.GetValue(instance)!;
+    }
+
+    private static Rect GetStoredHostBounds(IEffect effect)
+    {
+        var tryGetBoundsMethod = typeof(EffectorRuntime).GetMethod(
+            "TryGetHostVisualBounds",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        var args = new object?[] { effect, null };
+        var success = (bool)tryGetBoundsMethod.Invoke(null, args)!;
+
+        Assert.True(success);
+        return Assert.IsType<Rect>(args[1]);
+    }
+
+    private static Rect GetVisualBoundsRelativeTo(Visual visual, Visual root)
+    {
+        var topLeft = visual.TranslatePoint(new Point(0d, 0d), root);
+        var topRight = visual.TranslatePoint(new Point(visual.Bounds.Width, 0d), root);
+        var bottomLeft = visual.TranslatePoint(new Point(0d, visual.Bounds.Height), root);
+        var bottomRight = visual.TranslatePoint(new Point(visual.Bounds.Width, visual.Bounds.Height), root);
+
+        Assert.True(topLeft.HasValue);
+        Assert.True(topRight.HasValue);
+        Assert.True(bottomLeft.HasValue);
+        Assert.True(bottomRight.HasValue);
+
+        var minX = Math.Min(Math.Min(topLeft!.Value.X, topRight!.Value.X), Math.Min(bottomLeft!.Value.X, bottomRight!.Value.X));
+        var minY = Math.Min(Math.Min(topLeft.Value.Y, topRight.Value.Y), Math.Min(bottomLeft.Value.Y, bottomRight.Value.Y));
+        var maxX = Math.Max(Math.Max(topLeft.Value.X, topRight.Value.X), Math.Max(bottomLeft.Value.X, bottomRight.Value.X));
+        var maxY = Math.Max(Math.Max(topLeft.Value.Y, topRight.Value.Y), Math.Max(bottomLeft.Value.Y, bottomRight.Value.Y));
+        return new Rect(minX, minY, Math.Max(0d, maxX - minX), Math.Max(0d, maxY - minY));
     }
 
     private static string GetScreenshotPath(string fileName)

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -762,6 +762,51 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public void GridShaderEffect_RuntimeShader_Composites_Like_Fallback()
+    {
+        if (!EffectorRuntime.DirectRuntimeShadersEnabled)
+        {
+            return;
+        }
+
+        using var snapshotSurface = SKSurface.Create(new SKImageInfo(96, 96));
+        Assert.NotNull(snapshotSurface);
+        snapshotSurface!.Canvas.Clear(new SKColor(0xFF, 0x70, 0x43, 0xFF));
+        snapshotSurface.Canvas.Flush();
+
+        using var snapshot = snapshotSurface.Snapshot();
+        var context = new SkiaShaderEffectContext(
+            new SkiaEffectContext(1d, usesOpacitySaveLayer: false),
+            snapshot,
+            new SKRect(0, 0, 96, 96),
+            new SKRect(0, 0, 96, 96));
+
+        using var shaderEffect = new GridShaderEffectFactory().CreateShaderEffect(
+            new object[] { 12d, 0.8d, Color.Parse("#00D9FF") },
+            context);
+
+        Assert.NotNull(shaderEffect);
+        Assert.NotNull(shaderEffect!.Shader);
+        Assert.NotNull(shaderEffect.FallbackRenderer);
+
+        using var runtime = RenderShaderEffectComposite(snapshot, shaderEffect, useRuntimeShader: true);
+        using var fallback = RenderShaderEffectComposite(snapshot, shaderEffect, useRuntimeShader: false);
+
+        AssertColorClose(runtime.GetPixel(18, 18), fallback.GetPixel(18, 18), tolerance: 4);
+        AssertColorClose(runtime.GetPixel(12, 18), fallback.GetPixel(12, 18), tolerance: 8);
+        AssertColorClose(runtime.GetPixel(18, 12), fallback.GetPixel(18, 12), tolerance: 8);
+    }
+
+    [Fact]
+    public void OverlayOnlySampleShaders_Premultiply_RuntimeShaderOutput()
+    {
+        AssertShaderPremultipliesColorOutput(typeof(GridShaderEffectFactory));
+        AssertShaderPremultipliesColorOutput(typeof(SpotlightShaderEffectFactory));
+        AssertShaderPremultipliesColorOutput(typeof(PointerSpotlightShaderEffectFactory));
+        AssertShaderPremultipliesColorOutput(typeof(ReactiveGridShaderEffectFactory));
+    }
+
+    [Fact]
     public void DirectRuntimeShaderPath_IsEnabledByDefault_On_Supported_SkiaSharp()
     {
         var skiaVersion = typeof(SKRuntimeEffect).Assembly.GetName().Version;
@@ -2222,6 +2267,86 @@ public sealed class EffectorRuntimeBehaviorTests
         using var filteredImage = surface.Snapshot();
         filteredImage.ReadPixels(bitmap.Info, bitmap.GetPixels(), bitmap.RowBytes, 0, 0);
         return bitmap;
+    }
+
+    private static SKBitmap RenderShaderEffectComposite(SKImage snapshot, SkiaShaderEffect shaderEffect, bool useRuntimeShader)
+    {
+        var width = snapshot.Width;
+        var height = snapshot.Height;
+        var bitmap = new SKBitmap(width, height);
+
+        using var surface = SKSurface.Create(new SKImageInfo(width, height));
+        Assert.NotNull(surface);
+
+        var canvas = surface!.Canvas;
+        canvas.Clear(SKColors.White);
+        canvas.DrawImage(snapshot, 0, 0);
+
+        var destinationRect = shaderEffect.DestinationRect ?? SKRect.Create(width, height);
+        var restoreCount = canvas.Save();
+        try
+        {
+            canvas.ClipRect(destinationRect);
+
+            using var layerPaint = new SKPaint
+            {
+                BlendMode = shaderEffect.BlendMode,
+                IsAntialias = shaderEffect.IsAntialias
+            };
+            var layerRestoreCount = canvas.SaveLayer(destinationRect, layerPaint);
+            try
+            {
+                if (useRuntimeShader)
+                {
+                    Assert.NotNull(shaderEffect.Shader);
+                    using var paint = new SKPaint
+                    {
+                        Shader = shaderEffect.Shader,
+                        BlendMode = SKBlendMode.SrcOver,
+                        IsAntialias = shaderEffect.IsAntialias
+                    };
+                    canvas.DrawRect(destinationRect, paint);
+                }
+                else
+                {
+                    shaderEffect.RenderFallback(canvas, snapshot);
+                }
+
+                using var maskPaint = new SKPaint { BlendMode = SKBlendMode.DstIn };
+                canvas.DrawImage(snapshot, 0, 0, maskPaint);
+            }
+            finally
+            {
+                canvas.RestoreToCount(layerRestoreCount);
+            }
+        }
+        finally
+        {
+            canvas.RestoreToCount(restoreCount);
+        }
+
+        canvas.Flush();
+        using var image = surface.Snapshot();
+        image.ReadPixels(bitmap.Info, bitmap.GetPixels(), bitmap.RowBytes, 0, 0);
+        return bitmap;
+    }
+
+    private static void AssertColorClose(SKColor actual, SKColor expected, int tolerance)
+    {
+        Assert.True(Math.Abs(actual.Red - expected.Red) <= tolerance, $"Red mismatch: actual={actual.Red}, expected={expected.Red}, tolerance={tolerance}.");
+        Assert.True(Math.Abs(actual.Green - expected.Green) <= tolerance, $"Green mismatch: actual={actual.Green}, expected={expected.Green}, tolerance={tolerance}.");
+        Assert.True(Math.Abs(actual.Blue - expected.Blue) <= tolerance, $"Blue mismatch: actual={actual.Blue}, expected={expected.Blue}, tolerance={tolerance}.");
+        Assert.True(Math.Abs(actual.Alpha - expected.Alpha) <= tolerance, $"Alpha mismatch: actual={actual.Alpha}, expected={expected.Alpha}, tolerance={tolerance}.");
+    }
+
+    private static void AssertShaderPremultipliesColorOutput(Type factoryType)
+    {
+        var shaderSourceField = factoryType.GetField("ShaderSource", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(shaderSourceField);
+
+        var shaderSource = Assert.IsType<string>(shaderSourceField!.GetRawConstantValue());
+        Assert.Contains("premulAlpha", shaderSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("return half4(red, green, blue, alpha);", shaderSource, StringComparison.Ordinal);
     }
 
     private static T ReadProperty<T>(object instance, string propertyName)

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -221,6 +221,67 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public async Task HostTransformPreference_Is_RenderThreadSafe_After_TransformMutation()
+    {
+        var effect = RunOnUiThread(() =>
+        {
+            var instance = new GridShaderEffect
+            {
+                CellSize = 16d,
+                Strength = 0.4d,
+                Color = Color.Parse("#00D9FF")
+            };
+
+            var scale = new ScaleTransform(1d, 1d);
+            var host = new Border
+            {
+                Width = 120,
+                Height = 80,
+                Effect = instance,
+                RenderTransform = scale,
+                RenderTransformOrigin = RelativePoint.Center
+            };
+
+            var canvas = new Canvas
+            {
+                Width = 320,
+                Height = 220,
+                Children = { host }
+            };
+
+            var window = new Window
+            {
+                Width = 320,
+                Height = 220,
+                Content = canvas
+            };
+
+            Canvas.SetLeft(host, 48d);
+            Canvas.SetTop(host, 36d);
+            window.Show();
+            window.UpdateLayout();
+
+            scale.ScaleX = 1.4d;
+            scale.ScaleY = 1.25d;
+            return instance;
+        });
+
+        var result = await Task.Run(() =>
+        {
+            var shouldPreferHostBounds = typeof(EffectorRuntime).GetMethod(
+                "ShouldPreferHostBounds",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            var args = new object?[] { effect, null };
+            var shouldPrefer = (bool)shouldPreferHostBounds.Invoke(null, args)!;
+            return (shouldPrefer, size: Assert.IsType<Size>(args[1]));
+        });
+
+        Assert.True(result.shouldPrefer);
+        Assert.Equal(120d, result.size.Width, 3);
+        Assert.Equal(80d, result.size.Height, 3);
+    }
+
+    [Fact]
     public void GetEffectOutputPadding_UsesCustomFactory_ForGlowEffect()
     {
         RunOnUiThread(() =>

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -495,9 +495,24 @@ public sealed class EffectorRuntimeBehaviorTests
         var staleClipRect = new Rect(48d, 36d, 120d, 80d);
         var transformedHostBounds = new Rect(24d, 26d, 168d, 100d);
 
-        var selected = (Rect?)selectMethod.Invoke(null, new object?[] { staleClipRect, transformedHostBounds, null, true });
+        var selected = (Rect?)selectMethod.Invoke(null, new object?[] { staleClipRect, transformedHostBounds, null, true, new Size(120d, 80d) });
 
         Assert.Equal(transformedHostBounds, selected);
+    }
+
+    [Fact]
+    public void ShaderBoundsSelection_Clips_TransformedHostBounds_When_ClipRect_Is_Materially_Smaller()
+    {
+        var selectMethod = typeof(EffectorRuntime).GetMethod(
+            "SelectAuthoritativeEffectRectForHostPreference",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        var viewportClipRect = new Rect(48d, 36d, 72d, 44d);
+        var transformedHostBounds = new Rect(24d, 26d, 168d, 100d);
+
+        var selected = (Rect?)selectMethod.Invoke(null, new object?[] { viewportClipRect, transformedHostBounds, null, true, new Size(120d, 80d) });
+
+        Assert.Equal(transformedHostBounds.Intersect(viewportClipRect), selected);
     }
 
     [Fact]

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -577,6 +577,21 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public void ShaderBoundsSelection_Clips_TransformedHostBounds_When_ClipRect_Is_Smaller_Than_TransformedHost_But_Larger_Than_UnclippedSize()
+    {
+        var selectMethod = typeof(EffectorRuntime).GetMethod(
+            "SelectAuthoritativeEffectRectForHostPreference",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        var partiallyVisibleClipRect = new Rect(33d, 26d, 150d, 100d);
+        var transformedHostBounds = new Rect(24d, 26d, 168d, 100d);
+
+        var selected = (Rect?)selectMethod.Invoke(null, new object?[] { partiallyVisibleClipRect, transformedHostBounds, null, true, new Size(120d, 80d) });
+
+        Assert.Equal(transformedHostBounds.Intersect(partiallyVisibleClipRect), selected);
+    }
+
+    [Fact]
     public void ShaderIntermediateSurfaceBounds_Are_Derived_From_EffectBounds_Not_DeviceClip()
     {
         var resolveMethod = typeof(EffectorRuntime).GetMethod(


### PR DESCRIPTION
# PR Summary: Fix shader anchor drift with `RenderTransform`

## Context

- Fixes: https://github.com/wieslawsoltes/Effector/issues/7
- Branch: `fix/shader-rendertransform-anchor-shift`
- Commits:
  - `16864c8` `Track host bounds on transform mutations`
  - `b8f0f0c` `Prefer host bounds for transformed shader effects`
  - `5254bec` `Add RenderTransform shader regression coverage`

## Problem

Effector's shader pipeline could shift the visual's apparent anchor point when an active shader effect was combined with a non-identity Avalonia `RenderTransform`, especially `ScaleTransform` with `RenderTransformOrigin="0.5,0.5"`.

The underlying failure mode was not shader compilation or `ISkiaShaderEffectFactory` itself. The problem was the coordinate source used when the shader overlay was composited back onto the original canvas:

1. Host bounds were cached for the effected visual.
2. When the existing `RenderTransform` object mutated in place, for example changing `ScaleTransform.ScaleX` or `ScaleTransform.ScaleY`, the host-bounds cache was not refreshed.
3. During shader composition, the runtime could continue using stale pre-transform bounds or prefer a stale clip rect instead of the updated transformed host bounds.
4. That stale rect caused the captured shader overlay to be reintroduced at the wrong device position, which looked like the content anchor was drifting while scaling.

## Root Cause

There were two coupled issues:

### 1. Missing invalidation for in-place transform mutation

`SkiaEffectInputManager` subscribed to:

- `Visual.BoundsProperty`
- `Visual.RenderTransformProperty`
- layout/viewport updates

That was insufficient for transforms like:

```csharp
var scale = new ScaleTransform(1.0, 1.0);
host.RenderTransform = scale;
scale.ScaleX = 1.4;
scale.ScaleY = 1.25;
```

In that case, `RenderTransformProperty` does not change because the same transform instance remains assigned to the visual. Only the transform object's internal matrix changes. As a result, Effector could keep stale host bounds even though Avalonia was already rendering the visual with the updated transform.

### 2. Bounds selection favored clip rects too aggressively

Even when host bounds were available, the shader runtime still favored `effectClipRect` in some cases. On transformed visuals, that is risky because the clip rect may not reflect the correct transformed target area for the overlay composition step. The runtime needed to treat the tracked host bounds as authoritative when a non-identity host transform was active.

## Implementation

### 1. Refresh host bounds when a mutable transform changes

File: `src/Effector/SkiaEffectInputManager.cs`

Changes:

- Added a subscription to `Visual.RenderTransformOriginProperty`.
- Added tracking for the currently assigned `Transform` instance.
- Hooked the transform's `Changed` event when the assigned `RenderTransform` is a mutable Avalonia `Transform`.
- Detached and reattached the observer when the visual's `RenderTransform` reference changes.
- Routed transform change notifications through the existing `OnBoundsChanged()` path so host bounds update immediately without requiring a layout pass.

Effect:

- Bounds now refresh when callers mutate the existing transform object in place.
- The fix matches the real bug scenario reported in issue #7.

### 2. Prefer tracked host bounds for transformed shader hosts

File: `src/Effector/EffectorRuntime.cs`

Changes:

- Added `TryGetHostVisual(...)` so the runtime can inspect the current host visual for the active effect.
- Added `ShouldPreferHostBounds(...)` to detect a non-identity `RenderTransform` on the host visual.
- Introduced `SelectAuthoritativeEffectRectCandidateWithHostPreference(...)`.
- Updated shader begin/composite rect selection to prefer tracked host bounds when the host visual has an active non-identity transform.

Effect:

- The shader capture and overlay path now uses updated transformed host bounds instead of blindly trusting a potentially stale clip rect.
- This keeps the shader overlay aligned with the same transformed area as the base visual content.

### 3. Add regression coverage

File: `tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs`

Added tests:

- `HostBounds_Update_When_RenderTransform_Mutates_InPlace`
  - Verifies that changing `ScaleTransform.ScaleX/ScaleY` on the existing transform instance updates the stored host bounds immediately.
  - This test intentionally does **not** call `UpdateLayout()` after the transform mutation, so it validates the new transform-change observer rather than a later layout refresh.

- `ShaderBoundsSelection_Prefers_TransformedHostBounds_Over_ClipRect`
  - Verifies that transformed host bounds win over a stale clip rect when host preference is enabled.

Also added helper methods for reading stored host bounds and computing transformed visual bounds relative to a root visual.

## Why the commit split looks this way

The branch is intentionally split into three commits to keep review scope narrow:

1. `16864c8` isolates event/invalidation wiring.
2. `b8f0f0c` isolates runtime bounds-selection behavior.
3. `5254bec` adds only regression coverage.

That structure makes it easier to review causality:

- first make the data update correctly,
- then make the runtime trust the right data,
- then codify the behavior in tests.

## Verification

### Passed

- `dotnet test tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj`

This includes the new regression tests and confirms the runtime test project remains green after the fix.

### Failed separately during broader solution validation

- `dotnet test Effector.slnx`

This surfaced a separate build failure in `samples/Effector.Sample.Effects`, with generic constraint errors such as:

- `The type 'Effector.Sample.Effects.GridShaderEffect' cannot be used as type parameter 'TEffect' in 'ISkiaEffectFactory<TEffect>'`

That failure is outside the scope of this RenderTransform fix and was not introduced by the targeted runtime changes in this branch. The fix itself is validated by the runtime test project above.

## Risk assessment

### Low-risk areas

- Transform mutation tracking uses Avalonia's existing `Transform.Changed` event.
- The runtime preference change is narrowly gated to hosts with non-identity transforms.
- Existing non-transformed shader behavior stays on the previous rect-selection path.

### Things to watch

- Hosts using non-`Transform` `ITransform` implementations will still rely on property/layout updates rather than the new direct `Changed` event hook.
- If future Avalonia compositor behavior changes how `effectClipRect` is reported, the explicit transformed-host preference should still be the safer choice for overlay alignment.

## Suggested PR description

Fix shader overlay anchor drift when shader effects are combined with non-identity `RenderTransform` values.

The root cause was stale host-bounds tracking for in-place transform mutations like `ScaleTransform.ScaleX/ScaleY`, combined with rect selection that could still favor a stale clip rect over the transformed host bounds. This change updates host bounds when mutable transforms change, prefers host bounds for transformed shader hosts, and adds regression coverage for both behaviors.
