### PR TITLE
Add Compiz-inspired transition sample and multi-image shader support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           mkdir -p artifacts/headless-screenshots
           AVALONIA_SCREENSHOT_DIR="${GITHUB_WORKSPACE}/artifacts/headless-screenshots" \
-          DYLD_LIBRARY_PATH="${GITHUB_WORKSPACE}/tests/Effector.Runtime.Tests/bin/Release/${{ env.RUNTIME_TESTS_TARGET_FRAMEWORK }}/runtimes/osx/native" \
+          DYLD_LIBRARY_PATH="${GITHUB_WORKSPACE}/tests/Effector.Runtime.Tests/bin/Release/${{ env.RUNTIME_TESTS_TARGET_FRAMEWORK }}/runtimes/osx-arm64/native:${GITHUB_WORKSPACE}/tests/Effector.Runtime.Tests/bin/Release/${{ env.RUNTIME_TESTS_TARGET_FRAMEWORK }}/runtimes/osx/native" \
           dotnet test tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj -c Release --no-build --logger trx --results-directory artifacts/test/runtime
 
       - name: Upload runtime test results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           mkdir -p artifacts/headless-screenshots
           AVALONIA_SCREENSHOT_DIR="${GITHUB_WORKSPACE}/artifacts/headless-screenshots" \
-          DYLD_LIBRARY_PATH="${GITHUB_WORKSPACE}/tests/Effector.Runtime.Tests/bin/Release/${{ env.RUNTIME_TESTS_TARGET_FRAMEWORK }}/runtimes/osx/native" \
+          DYLD_LIBRARY_PATH="${GITHUB_WORKSPACE}/tests/Effector.Runtime.Tests/bin/Release/${{ env.RUNTIME_TESTS_TARGET_FRAMEWORK }}/runtimes/osx-arm64/native:${GITHUB_WORKSPACE}/tests/Effector.Runtime.Tests/bin/Release/${{ env.RUNTIME_TESTS_TARGET_FRAMEWORK }}/runtimes/osx/native" \
           dotnet test tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj -c Release --no-build --logger trx --results-directory artifacts/test/runtime
 
   nativeaot-sample:

--- a/Effector.slnx
+++ b/Effector.slnx
@@ -1,5 +1,7 @@
 <Solution>
   <Folder Name="/samples/">
+    <Project Path="samples/Effector.Compiz.Sample.App/Effector.Compiz.Sample.App.csproj" />
+    <Project Path="samples/Effector.Compiz.Sample.Effects/Effector.Compiz.Sample.Effects.csproj" />
     <Project Path="samples/Effector.Sample.App/Effector.Sample.App.csproj" />
     <Project Path="samples/Effector.Sample.Effects/Effector.Sample.Effects.csproj" />
   </Folder>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Effector brings extensible Skia-backed custom effects to Avalonia `12.0.0` while
 - Support typed Skia filter effects, runtime shader effects, and pointer-driven interactive effects.
 - Use build-time weaving and app-local Avalonia binary patching instead of runtime detours.
 - Work with animation, parsing, immutable snapshots, render-thread safety, and NativeAOT publish flows.
-- Ship a sample gallery with color, convolution, shader, interactive, and burn-away effect examples.
+- Ship a sample gallery with color, convolution, shader, interactive, burn-away, and compiz-style route transition examples.
 
 ## Compatibility
 
@@ -215,6 +215,34 @@ public sealed class ScanlineShaderEffectFactory :
     }
 }
 ```
+
+## Secondary Shader Images
+
+Multi-input shader effects can carry extra bitmap inputs through `SkiaShaderImageHandle`, `SkiaShaderImageRegistry`, and `SkiaShaderImageLease`. The handle is a value type, so it remains compatible with Effector's immutable snapshot model, while a lease keeps the underlying `SKImage` alive until the returned `SkiaShaderEffect` is disposed.
+
+```csharp
+public static readonly StyledProperty<SkiaShaderImageHandle> FromImageProperty =
+    AvaloniaProperty.Register<MyTransitionEffect, SkiaShaderImageHandle>(nameof(FromImage));
+
+using var fromBitmap = CapturePage(...);
+var fromHandle = SkiaShaderImageRegistry.Register(fromBitmap);
+
+if (SkiaShaderImageRegistry.TryAcquire(effect.FromImage, out var fromLease))
+{
+    return SkiaRuntimeShaderBuilder.Create(
+        sksl,
+        context,
+        configureOwnedChildren: (children, _, ownedResources) =>
+        {
+            var fromShader = fromLease.Image.ToShader(SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
+            children.Add("fromImage", fromShader);
+            ownedResources.Add(fromShader);
+        },
+        ownedResources: new IDisposable[] { fromLease });
+}
+```
+
+The new compiz sample uses this path to feed current-page and next-page captures into a single Effector shader effect for route transitions. It is an Avalonia/Effector port inspired by Max Leiter's `compiz-web` project: https://github.com/MaxLeiter/compiz-web
 
 ## Interactive Effects
 

--- a/samples/Effector.Compiz.Sample.App/App.axaml
+++ b/samples/Effector.Compiz.Sample.App/App.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Effector.Compiz.Sample.App.App"
+             RequestedThemeVariant="Dark">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/samples/Effector.Compiz.Sample.App/App.axaml.cs
+++ b/samples/Effector.Compiz.Sample.App/App.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace Effector.Compiz.Sample.App;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/samples/Effector.Compiz.Sample.App/Controls/TransitionPresenter.axaml
+++ b/samples/Effector.Compiz.Sample.App/Controls/TransitionPresenter.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Effector.Compiz.Sample.App.Controls.TransitionPresenter"
+             ClipToBounds="True">
+  <Grid ClipToBounds="True">
+    <ContentControl x:Name="NextHost"
+                    HorizontalContentAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
+                    IsHitTestVisible="False" />
+    <ContentControl x:Name="CurrentHost"
+                    HorizontalContentAlignment="Stretch"
+                    VerticalContentAlignment="Stretch" />
+    <Border x:Name="OverlayHost"
+            IsVisible="False"
+            IsHitTestVisible="False"
+            Background="#FFFFFFFF" />
+  </Grid>
+</UserControl>

--- a/samples/Effector.Compiz.Sample.App/Controls/TransitionPresenter.axaml.cs
+++ b/samples/Effector.Compiz.Sample.App/Controls/TransitionPresenter.axaml.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Effector;
+using Effector.Compiz.Sample.Effects;
+using SkiaSharp;
+
+namespace Effector.Compiz.Sample.App.Controls;
+
+public partial class TransitionPresenter : UserControl
+{
+    private readonly Stopwatch _stopwatch = new();
+    private readonly DispatcherTimer _timer;
+    private readonly CompizTransitionEffect _transitionEffect;
+    private readonly ContentControl _currentHost;
+    private readonly ContentControl _nextHost;
+    private readonly Border _overlayHost;
+    private TaskCompletionSource<bool>? _transitionCompletion;
+    private CompizTransitionDescriptor _activeDescriptor = CompizTransitionCatalog.All[0];
+    private Control? _pendingContent;
+    private SkiaShaderImageHandle _fromHandle;
+    private SkiaShaderImageHandle _toHandle;
+    private bool _isTransitioning;
+
+    public TransitionPresenter()
+    {
+        AvaloniaXamlLoader.Load(this);
+
+        _currentHost = RequireControl<ContentControl>("CurrentHost");
+        _nextHost = RequireControl<ContentControl>("NextHost");
+        _overlayHost = RequireControl<Border>("OverlayHost");
+        _transitionEffect = new CompizTransitionEffect();
+        _overlayHost.Effect = _transitionEffect;
+
+        _timer = new DispatcherTimer(DispatcherPriority.Render)
+        {
+            Interval = TimeSpan.FromMilliseconds(16d)
+        };
+        _timer.Tick += OnTransitionTick;
+
+        DetachedFromVisualTree += OnDetachedFromVisualTree;
+    }
+
+    public void SetInitialPage(Control page)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ReleaseHandles();
+        _pendingContent = null;
+        _isTransitioning = false;
+        _timer.Stop();
+        _stopwatch.Reset();
+
+        _currentHost.Content = null;
+        _currentHost.Content = page;
+        _currentHost.IsVisible = true;
+        _nextHost.Content = null;
+        _nextHost.IsVisible = false;
+        _overlayHost.IsVisible = false;
+        ResetEffectInputs();
+    }
+
+    public async Task TransitionToAsync(Control page, CompizTransitionDescriptor descriptor, Point? click)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (_isTransitioning || _currentHost.Content is null)
+        {
+            SetInitialPage(page);
+            return;
+        }
+
+        _activeDescriptor = descriptor;
+        _pendingContent = page;
+        _nextHost.Content = null;
+        _nextHost.Content = page;
+        _nextHost.IsVisible = true;
+
+        await Dispatcher.UIThread.InvokeAsync(
+            () =>
+            {
+                UpdateLayout();
+                _currentHost.UpdateLayout();
+                _nextHost.UpdateLayout();
+            },
+            DispatcherPriority.Render);
+
+        using var fromBitmap = Capture(_currentHost);
+        using var toBitmap = Capture(_nextHost);
+
+        ReleaseHandles();
+        _fromHandle = SkiaShaderImageRegistry.Register(fromBitmap);
+        _toHandle = SkiaShaderImageRegistry.Register(toBitmap);
+
+        var normalizedClick = NormalizeClick(click);
+        _transitionEffect.Kind = descriptor.Kind;
+        _transitionEffect.FromImage = _fromHandle;
+        _transitionEffect.ToImage = _toHandle;
+        _transitionEffect.Progress = 0d;
+        _transitionEffect.Time = 0d;
+        _transitionEffect.ClickX = normalizedClick.X;
+        _transitionEffect.ClickY = normalizedClick.Y;
+
+        _currentHost.IsVisible = false;
+        _nextHost.IsVisible = false;
+        _overlayHost.IsVisible = true;
+
+        _isTransitioning = true;
+        _transitionCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _stopwatch.Restart();
+        _timer.Start();
+
+        await _transitionCompletion.Task;
+    }
+
+    private void OnTransitionTick(object? sender, EventArgs e)
+    {
+        var duration = Math.Max(_activeDescriptor.Duration.TotalSeconds, 0.001d);
+        var elapsed = _stopwatch.Elapsed.TotalSeconds;
+        var raw = Math.Clamp(elapsed / duration, 0d, 1d);
+
+        _transitionEffect.Progress = Ease(raw);
+        _transitionEffect.Time = elapsed;
+
+        if (raw >= 1d)
+        {
+            CompleteTransition();
+        }
+    }
+
+    private void CompleteTransition()
+    {
+        _timer.Stop();
+        _stopwatch.Reset();
+
+        var nextContent = _pendingContent;
+        _pendingContent = null;
+        _nextHost.Content = null;
+
+        if (nextContent is not null)
+        {
+            _currentHost.Content = null;
+            _currentHost.Content = nextContent;
+        }
+
+        _currentHost.IsVisible = true;
+        _nextHost.IsVisible = false;
+        _overlayHost.IsVisible = false;
+
+        ResetEffectInputs();
+        ReleaseHandles();
+
+        _isTransitioning = false;
+        _transitionCompletion?.TrySetResult(true);
+        _transitionCompletion = null;
+    }
+
+    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        _timer.Stop();
+        _stopwatch.Reset();
+        _transitionCompletion?.TrySetResult(true);
+        _transitionCompletion = null;
+        ReleaseHandles();
+    }
+
+    private RenderTargetBitmap Capture(Control host)
+    {
+        var size = host.Bounds.Size;
+        if (size.Width <= 0d || size.Height <= 0d)
+        {
+            size = Bounds.Size;
+        }
+
+        var renderScaling = TopLevel.GetTopLevel(this)?.RenderScaling ?? 1d;
+        var pixelSize = new PixelSize(
+            Math.Max(1, (int)Math.Ceiling(size.Width * renderScaling)),
+            Math.Max(1, (int)Math.Ceiling(size.Height * renderScaling)));
+
+        var bitmap = new RenderTargetBitmap(
+            pixelSize,
+            new Vector(96d * renderScaling, 96d * renderScaling));
+        bitmap.Render(host);
+        return bitmap;
+    }
+
+    private Point NormalizeClick(Point? point)
+    {
+        if (!point.HasValue || Bounds.Width <= 0d || Bounds.Height <= 0d)
+        {
+            return new Point(0.5d, 0.5d);
+        }
+
+        return new Point(
+            Math.Clamp(point.Value.X / Bounds.Width, 0d, 1d),
+            Math.Clamp(point.Value.Y / Bounds.Height, 0d, 1d));
+    }
+
+    private void ResetEffectInputs()
+    {
+        _transitionEffect.FromImage = default;
+        _transitionEffect.ToImage = default;
+        _transitionEffect.Progress = 0d;
+        _transitionEffect.Time = 0d;
+        _transitionEffect.ClickX = 0.5d;
+        _transitionEffect.ClickY = 0.5d;
+    }
+
+    private void ReleaseHandles()
+    {
+        SkiaShaderImageRegistry.Release(_fromHandle);
+        SkiaShaderImageRegistry.Release(_toHandle);
+        _fromHandle = default;
+        _toHandle = default;
+    }
+
+    private static double Ease(double value) =>
+        value < 0.5d
+            ? 2d * value * value
+            : 1d - (Math.Pow((-2d * value) + 2d, 2d) / 2d);
+
+    private T RequireControl<T>(string name)
+        where T : Control =>
+        this.FindControl<T>(name)
+        ?? throw new InvalidOperationException(
+            $"Could not find required control '{name}' in {nameof(TransitionPresenter)}.");
+}

--- a/samples/Effector.Compiz.Sample.App/Controls/TransitionPresenter.axaml.cs
+++ b/samples/Effector.Compiz.Sample.App/Controls/TransitionPresenter.axaml.cs
@@ -71,7 +71,16 @@ public partial class TransitionPresenter : UserControl
         ArgumentNullException.ThrowIfNull(page);
         ArgumentNullException.ThrowIfNull(descriptor);
 
-        if (_isTransitioning || _currentHost.Content is null)
+        if (_isTransitioning)
+        {
+            var priorTransitionCompletion = _transitionCompletion;
+            _transitionCompletion = null;
+            SetInitialPage(page);
+            priorTransitionCompletion?.TrySetResult(true);
+            return;
+        }
+
+        if (_currentHost.Content is null)
         {
             SetInitialPage(page);
             return;

--- a/samples/Effector.Compiz.Sample.App/Effector.Compiz.Sample.App.csproj
+++ b/samples/Effector.Compiz.Sample.App/Effector.Compiz.Sample.App.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>Effector.Compiz.Sample.App</AssemblyName>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Effector\Effector.csproj"
+                      AdditionalProperties="GeneratePackageOnBuild=false" />
+    <ProjectReference Include="..\Effector.Compiz.Sample.Effects\Effector.Compiz.Sample.Effects.csproj" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
+  </ItemGroup>
+
+  <Import Project="..\..\src\Effector.Build\buildTransitive\Effector.Build.props" />
+  <Import Project="..\..\src\Effector.Build\buildTransitive\Effector.Build.targets" />
+</Project>

--- a/samples/Effector.Compiz.Sample.App/MainWindow.axaml
+++ b/samples/Effector.Compiz.Sample.App/MainWindow.axaml
@@ -1,0 +1,102 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:Effector.Compiz.Sample.App.Controls"
+        x:Class="Effector.Compiz.Sample.App.MainWindow"
+        Width="1380"
+        Height="940"
+        MinWidth="980"
+        MinHeight="720"
+        Title="Effector Compiz Sample"
+        FontFamily="avares://Avalonia.Fonts.Inter#Inter"
+        ExtendClientAreaToDecorationsHint="True"
+        TransparencyLevelHint="AcrylicBlur">
+  <Grid RowDefinitions="Auto,*">
+    <Border Grid.Row="0"
+            Padding="24,18"
+            Background="#E40A1020"
+            BorderBrush="#26FFFFFF"
+            BorderThickness="0,0,0,1">
+      <Grid RowDefinitions="Auto,Auto"
+            RowSpacing="10">
+        <Grid ColumnDefinitions="Auto,*,Auto"
+              ColumnSpacing="18">
+          <Button x:Name="BrandButton"
+                  Tag="/"
+                  Padding="14,10"
+                  Background="#261A365D"
+                  Foreground="#F7FBFF"
+                  FontSize="18"
+                  FontWeight="SemiBold"
+                  Content="Effector Compiz" />
+
+          <StackPanel Grid.Column="1"
+                      Orientation="Horizontal"
+                      Spacing="10"
+                      VerticalAlignment="Center">
+            <Button x:Name="HomeNavButton"
+                    Tag="/"
+                    Padding="16,9"
+                    Background="Transparent"
+                    Foreground="#D9E7F9"
+                    Content="Home" />
+            <Button x:Name="AboutNavButton"
+                    Tag="/about"
+                    Padding="16,9"
+                    Background="Transparent"
+                    Foreground="#D9E7F9"
+                    Content="About" />
+            <Button x:Name="WorkNavButton"
+                    Tag="/work"
+                    Padding="16,9"
+                    Background="Transparent"
+                    Foreground="#D9E7F9"
+                    Content="Work" />
+            <Button x:Name="ContactNavButton"
+                    Tag="/contact"
+                    Padding="16,9"
+                    Background="Transparent"
+                    Foreground="#D9E7F9"
+                    Content="Contact" />
+          </StackPanel>
+
+          <StackPanel Grid.Column="2"
+                      Orientation="Horizontal"
+                      Spacing="12"
+                      VerticalAlignment="Center">
+            <Border Padding="12,8"
+                    Background="#1AFFFFFF"
+                    CornerRadius="999">
+              <TextBlock Text="Skia shader transitions"
+                         Foreground="#C5D9F2"
+                         FontSize="12"
+                         FontWeight="SemiBold" />
+            </Border>
+            <StackPanel Spacing="4"
+                        VerticalAlignment="Center">
+              <TextBlock Text="Effect"
+                         Foreground="#90A8C4"
+                         FontSize="12" />
+              <ComboBox x:Name="EffectPicker"
+                        Width="172" />
+            </StackPanel>
+          </StackPanel>
+        </Grid>
+
+        <TextBlock x:Name="EffectSummaryText"
+                   Grid.Row="1"
+                   Foreground="#A6B6CD"
+                   TextWrapping="Wrap" />
+      </Grid>
+    </Border>
+
+    <Border Grid.Row="1"
+            Margin="18"
+            CornerRadius="28"
+            Background="#FF0D1424"
+            BorderBrush="#1FFFFFFF"
+            BorderThickness="1"
+            ClipToBounds="True">
+      <controls:TransitionPresenter x:Name="TransitionHost" />
+    </Border>
+  </Grid>
+</Window>

--- a/samples/Effector.Compiz.Sample.App/MainWindow.axaml.cs
+++ b/samples/Effector.Compiz.Sample.App/MainWindow.axaml.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Effector.Compiz.Sample.App.Controls;
+using Effector.Compiz.Sample.App.Pages;
+using Effector.Compiz.Sample.Effects;
+
+namespace Effector.Compiz.Sample.App;
+
+public partial class MainWindow : Window
+{
+    private readonly TransitionOption[] _transitionOptions;
+    private readonly Random _random = new();
+    private readonly ComboBox _effectPicker;
+    private readonly TransitionPresenter _transitionHost;
+    private readonly TextBlock _effectSummaryText;
+    private readonly Button _homeNavButton;
+    private readonly Button _aboutNavButton;
+    private readonly Button _workNavButton;
+    private readonly Button _contactNavButton;
+    private string _currentRoute = "/";
+    private Avalonia.Point? _pendingClick;
+    private bool _stressStarted;
+
+    public MainWindow()
+    {
+        AvaloniaXamlLoader.Load(this);
+
+        _effectPicker = RequireControl<ComboBox>("EffectPicker");
+        _transitionHost = RequireControl<TransitionPresenter>("TransitionHost");
+        _effectSummaryText = RequireControl<TextBlock>("EffectSummaryText");
+        _homeNavButton = RequireControl<Button>("HomeNavButton");
+        _aboutNavButton = RequireControl<Button>("AboutNavButton");
+        _workNavButton = RequireControl<Button>("WorkNavButton");
+        _contactNavButton = RequireControl<Button>("ContactNavButton");
+        _transitionOptions = CreateTransitionOptions();
+        _effectPicker.ItemsSource = _transitionOptions;
+        _effectPicker.SelectedItem =
+            _transitionOptions.FirstOrDefault(static option => option.Id == TransitionPreferenceStore.Load())
+            ?? _transitionOptions[0];
+        _effectPicker.SelectionChanged += OnEffectSelectionChanged;
+
+        AddHandler(Button.ClickEvent, OnButtonClicked, RoutingStrategies.Bubble, handledEventsToo: true);
+        AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel, handledEventsToo: true);
+        Opened += OnOpened;
+
+        _transitionHost.SetInitialPage(CreatePage(_currentRoute));
+        UpdateNavigationState();
+        UpdateEffectSummary(GetSelectedOption(), appliedDescriptor: GetSelectedDescriptor(GetSelectedOption()));
+    }
+
+    private async void OnButtonClicked(object? sender, RoutedEventArgs e)
+    {
+        if (e.Source is not Button button || button.Tag is not string tag)
+        {
+            return;
+        }
+
+        if (string.Equals(tag, "sample-submit", StringComparison.Ordinal))
+        {
+            _effectSummaryText.Text = "Sample form submitted locally. The page stays interactive between shader transitions.";
+            return;
+        }
+
+        if (!tag.StartsWith("/", StringComparison.Ordinal) || string.Equals(tag, _currentRoute, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var option = GetSelectedOption();
+        var descriptor = GetSelectedDescriptor(option);
+        var pendingClick = _pendingClick;
+        _pendingClick = null;
+
+        await NavigateToRouteAsync(tag, option, descriptor, pendingClick);
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.Source is Button button && button.Tag is string tag && tag.StartsWith("/", StringComparison.Ordinal))
+        {
+            _pendingClick = e.GetPosition(_transitionHost);
+        }
+    }
+
+    private void OnEffectSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        var option = GetSelectedOption();
+        TransitionPreferenceStore.Save(option.Id);
+        UpdateEffectSummary(option, appliedDescriptor: GetSelectedDescriptor(option));
+    }
+
+    private async void OnOpened(object? sender, EventArgs e)
+    {
+        if (_stressStarted || !IsStressModeEnabled())
+        {
+            return;
+        }
+
+        _stressStarted = true;
+
+        try
+        {
+            await Dispatcher.UIThread.InvokeAsync(
+                () =>
+                {
+                    UpdateLayout();
+                    _transitionHost.UpdateLayout();
+                },
+                DispatcherPriority.Render);
+
+            await RunStressScenarioAsync();
+
+            Console.WriteLine("Compiz stress scenario completed.");
+            await Dispatcher.UIThread.InvokeAsync(Close, DispatcherPriority.Background);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("Compiz stress scenario failed: " + ex);
+            throw;
+        }
+    }
+
+    private TransitionOption GetSelectedOption() =>
+        _effectPicker.SelectedItem as TransitionOption ?? _transitionOptions[0];
+
+    private CompizTransitionDescriptor GetSelectedDescriptor(TransitionOption option)
+    {
+        if (option.Kind.HasValue)
+        {
+            return CompizTransitionCatalog.Get(option.Kind.Value);
+        }
+
+        return CompizTransitionCatalog.All[_random.Next(CompizTransitionCatalog.All.Length)];
+    }
+
+    private Control CreatePage(string route) =>
+        route switch
+        {
+            "/about" => new AboutPage(),
+            "/work" => new WorkPage(),
+            "/contact" => new ContactPage(),
+            _ => new HomePage()
+        };
+
+    private void UpdateNavigationState()
+    {
+        SetNavigationState(_homeNavButton, string.Equals(_currentRoute, "/", StringComparison.Ordinal));
+        SetNavigationState(_aboutNavButton, string.Equals(_currentRoute, "/about", StringComparison.Ordinal));
+        SetNavigationState(_workNavButton, string.Equals(_currentRoute, "/work", StringComparison.Ordinal));
+        SetNavigationState(_contactNavButton, string.Equals(_currentRoute, "/contact", StringComparison.Ordinal));
+    }
+
+    private void UpdateEffectSummary(TransitionOption option, CompizTransitionDescriptor appliedDescriptor)
+    {
+        _effectSummaryText.Text = option.Kind.HasValue
+            ? $"{appliedDescriptor.DisplayName}: {appliedDescriptor.Description}"
+            : $"Random mode is enabled. The next navigation will pick from {CompizTransitionCatalog.All.Length} transition shaders. Last preview: {appliedDescriptor.DisplayName}.";
+    }
+
+    private static void SetNavigationState(Button button, bool isActive)
+    {
+        button.Background = isActive
+            ? new SolidColorBrush(Color.Parse("#284C77FF"))
+            : Brushes.Transparent;
+        button.Foreground = isActive
+            ? Brushes.White
+            : new SolidColorBrush(Color.Parse("#D9E7F9"));
+    }
+
+    private static TransitionOption[] CreateTransitionOptions()
+    {
+        var options = CompizTransitionCatalog.All
+            .Select(static descriptor => new TransitionOption(descriptor.Id, descriptor.DisplayName, descriptor.Kind))
+            .ToList();
+        options.Add(new TransitionOption("random", "Random", kind: null));
+        return options.ToArray();
+    }
+
+    private async Task RunStressScenarioAsync()
+    {
+        var selectedEffectId = Environment.GetEnvironmentVariable("EFFECTOR_COMPIZ_AUTOSTRESS_EFFECT");
+        if (string.IsNullOrWhiteSpace(selectedEffectId))
+        {
+            selectedEffectId = "cube";
+        }
+
+        var selectedOption = _transitionOptions.FirstOrDefault(option =>
+            string.Equals(option.Id, selectedEffectId, StringComparison.OrdinalIgnoreCase));
+        if (selectedOption is not null)
+        {
+            _effectPicker.SelectedItem = selectedOption;
+        }
+
+        var iterations = ParseInt32EnvironmentVariable("EFFECTOR_COMPIZ_AUTOSTRESS_ITERATIONS", fallback: 20);
+        var forceGc = ParseBooleanEnvironmentVariable("EFFECTOR_COMPIZ_AUTOSTRESS_FORCE_GC", fallback: true);
+        var routes = new[] { "/about", "/work", "/contact", "/" };
+
+        for (var index = 0; index < iterations; index++)
+        {
+            var route = routes[index % routes.Length];
+            var click = CreateStressClickPoint(index);
+            var option = GetSelectedOption();
+            var descriptor = GetSelectedDescriptor(option);
+
+            Console.WriteLine(
+                $"Compiz stress transition {index + 1}/{iterations}: {_currentRoute} -> {route} using {descriptor.DisplayName}.");
+
+            await NavigateToRouteAsync(route, option, descriptor, click);
+
+            if (forceGc)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+        }
+
+        await Task.Delay(250);
+
+        if (forceGc)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+    }
+
+    private async Task NavigateToRouteAsync(
+        string route,
+        TransitionOption option,
+        CompizTransitionDescriptor descriptor,
+        Avalonia.Point? click)
+    {
+        if (!route.StartsWith("/", StringComparison.Ordinal) || string.Equals(route, _currentRoute, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        await _transitionHost.TransitionToAsync(CreatePage(route), descriptor, click);
+        _currentRoute = route;
+        UpdateNavigationState();
+        UpdateEffectSummary(option, descriptor);
+    }
+
+    private Avalonia.Point CreateStressClickPoint(int index)
+    {
+        var width = Math.Max(_transitionHost.Bounds.Width, 1d);
+        var height = Math.Max(_transitionHost.Bounds.Height, 1d);
+        var normalizedX = index % 2 == 0 ? 0.82d : 0.18d;
+        return new Avalonia.Point(width * normalizedX, height * 0.18d);
+    }
+
+    private static bool IsStressModeEnabled() =>
+        ParseBooleanEnvironmentVariable("EFFECTOR_COMPIZ_AUTOSTRESS", fallback: false);
+
+    private static bool ParseBooleanEnvironmentVariable(string name, bool fallback)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "1" or "true" or "yes" or "on" => true,
+            "0" or "false" or "no" or "off" => false,
+            _ => fallback
+        };
+    }
+
+    private static int ParseInt32EnvironmentVariable(string name, int fallback)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
+            ? parsed
+            : fallback;
+    }
+
+    private sealed class TransitionOption
+    {
+        public TransitionOption(string id, string displayName, CompizTransitionKind? kind)
+        {
+            Id = id;
+            DisplayName = displayName;
+            Kind = kind;
+        }
+
+        public string Id { get; }
+
+        public string DisplayName { get; }
+
+        public CompizTransitionKind? Kind { get; }
+
+        public override string ToString() => DisplayName;
+    }
+
+    private T RequireControl<T>(string name)
+        where T : Control =>
+        this.FindControl<T>(name)
+        ?? throw new InvalidOperationException(
+            $"Could not find required control '{name}' in {nameof(MainWindow)}.");
+}

--- a/samples/Effector.Compiz.Sample.App/Pages/AboutPage.axaml
+++ b/samples/Effector.Compiz.Sample.App/Pages/AboutPage.axaml
@@ -1,0 +1,82 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Effector.Compiz.Sample.App.Pages.AboutPage">
+  <Border Background="#FF0F172A"
+          Padding="48,42">
+    <Grid RowDefinitions="Auto,Auto,*"
+          RowSpacing="22">
+      <Border Width="116"
+              Height="4"
+              CornerRadius="999"
+              Background="#10B981" />
+
+      <TextBlock Grid.Row="1"
+                 Text="About the experiment"
+                 FontSize="46"
+                 FontWeight="SemiBold"
+                 Foreground="#F8FBFF" />
+
+      <Grid Grid.Row="2"
+            ColumnDefinitions="1.2*,0.8*"
+            ColumnSpacing="28">
+        <StackPanel Spacing="18">
+          <TextBlock Text="compiz-web proved that a route transition can feel like a composition effect instead of a page swap. This sample keeps that idea, but the rendering stack is Avalonia + Effector + SkiaSharp rather than HTML-in-Canvas + WebGL."
+                     FontSize="18"
+                     Foreground="#C0D1E8"
+                     TextWrapping="Wrap" />
+          <TextBlock Text="Each transition in this app runs as a real Effector shader effect. The presenter captures the current and next pages into bitmaps, registers them as shader inputs, and drives progress with the same eased timing model as the original web demo."
+                     Foreground="#A6BCD8"
+                     TextWrapping="Wrap" />
+          <TextBlock Text="Because the transition lives on the public effect API, it still benefits from Effector's immutable snapshot model, render-thread-safe factories, and CPU fallback rendering."
+                     Foreground="#A6BCD8"
+                     TextWrapping="Wrap" />
+          <StackPanel Orientation="Horizontal"
+                      Spacing="12">
+            <Button Tag="/work"
+                    Padding="18,12"
+                    Background="#3348D597"
+                    Foreground="White"
+                    FontWeight="SemiBold"
+                    Content="See the transition catalog" />
+            <Button Tag="/contact"
+                    Padding="18,12"
+                    Background="#1EFFFFFF"
+                    Foreground="#E8F1FF"
+                    Content="Open the contact form" />
+          </StackPanel>
+        </StackPanel>
+
+        <StackPanel Grid.Column="1"
+                    Spacing="16">
+          <Border Padding="18"
+                  CornerRadius="24"
+                  Background="#131D31">
+            <StackPanel Spacing="8">
+              <TextBlock Text="Effector"
+                         FontSize="22"
+                         FontWeight="SemiBold"
+                         Foreground="#F7FBFF" />
+              <TextBlock Text="Single-effect Avalonia visuals, immutable render snapshots, runtime SKSL, and build-time weaving."
+                         Foreground="#A8BDD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+
+          <Border Padding="18"
+                  CornerRadius="24"
+                  Background="#131D31">
+            <StackPanel Spacing="8">
+              <TextBlock Text="Transition surface"
+                         FontSize="22"
+                         FontWeight="SemiBold"
+                         Foreground="#F7FBFF" />
+              <TextBlock Text="An Avalonia user control captures page content, feeds two image handles into one shader effect, and swaps the live page when the animation completes."
+                         Foreground="#A8BDD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </Grid>
+    </Grid>
+  </Border>
+</UserControl>

--- a/samples/Effector.Compiz.Sample.App/Pages/AboutPage.axaml.cs
+++ b/samples/Effector.Compiz.Sample.App/Pages/AboutPage.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Effector.Compiz.Sample.App.Pages;
+
+public partial class AboutPage : UserControl
+{
+    public AboutPage()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/Effector.Compiz.Sample.App/Pages/ContactPage.axaml
+++ b/samples/Effector.Compiz.Sample.App/Pages/ContactPage.axaml
@@ -1,0 +1,103 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Effector.Compiz.Sample.App.Pages.ContactPage">
+  <Border Background="#FF0C1628"
+          Padding="48,42">
+    <Grid ColumnDefinitions="1.15*,0.85*"
+          ColumnSpacing="28">
+      <StackPanel Spacing="20">
+        <Border Width="116"
+                Height="4"
+                CornerRadius="999"
+                Background="#EC4899" />
+
+        <TextBlock Text="Interactive controls still work"
+                   FontSize="44"
+                   FontWeight="SemiBold"
+                   Foreground="#F8FBFF" />
+
+        <TextBlock Text="The contact page is here to prove the transition surface can sit on top of real Avalonia input controls, not just screenshots. Type, tab, focus, and then route away with another shader."
+                   FontSize="18"
+                   Foreground="#C0D1E8"
+                   TextWrapping="Wrap" />
+
+        <Border Padding="24"
+                CornerRadius="24"
+                Background="#141E33">
+          <Grid RowDefinitions="Auto,Auto,Auto,Auto"
+                RowSpacing="14">
+            <StackPanel Spacing="6">
+              <TextBlock Text="Name"
+                         Foreground="#C9D9EC" />
+              <TextBox PlaceholderText="Your name" />
+            </StackPanel>
+
+            <StackPanel Grid.Row="1"
+                        Spacing="6">
+              <TextBlock Text="Email"
+                         Foreground="#C9D9EC" />
+              <TextBox PlaceholderText="you@example.com" />
+            </StackPanel>
+
+            <StackPanel Grid.Row="2"
+                        Spacing="6">
+              <TextBlock Text="Message"
+                         Foreground="#C9D9EC" />
+              <TextBox AcceptsReturn="True"
+                       TextWrapping="Wrap"
+                       Height="120"
+                       PlaceholderText="Tell us which transition feels the most like classic Compiz." />
+            </StackPanel>
+
+            <StackPanel Grid.Row="3"
+                        Orientation="Horizontal"
+                        Spacing="12">
+              <Button Tag="sample-submit"
+                      Padding="18,12"
+                      Background="#3348D597"
+                      Foreground="White"
+                      FontWeight="SemiBold"
+                      Content="Send sample message" />
+              <Button Tag="/"
+                      Padding="18,12"
+                      Background="#1EFFFFFF"
+                      Foreground="#E8F1FF"
+                      Content="Back home" />
+            </StackPanel>
+          </Grid>
+        </Border>
+      </StackPanel>
+
+      <StackPanel Grid.Column="1"
+                  Spacing="16">
+        <Border Padding="22"
+                CornerRadius="24"
+                Background="#131D31">
+          <StackPanel Spacing="10">
+            <TextBlock Text="What to try"
+                       FontSize="22"
+                       FontWeight="SemiBold"
+                       Foreground="#F7FBFF" />
+            <TextBlock Text="1. Pick Random in the title bar." Foreground="#A8BDD8" />
+            <TextBlock Text="2. Click a route from different sides of the window." Foreground="#A8BDD8" />
+            <TextBlock Text="3. Return here and keep interacting with the form." Foreground="#A8BDD8" />
+          </StackPanel>
+        </Border>
+
+        <Border Padding="22"
+                CornerRadius="24"
+                Background="#131D31">
+          <StackPanel Spacing="10">
+            <TextBlock Text="Transition host"
+                       FontSize="22"
+                       FontWeight="SemiBold"
+                       Foreground="#F7FBFF" />
+            <TextBlock Text="During a route change, the current and next pages are captured to render targets, bound through image handles, and replaced by one Effector shader effect until the animation completes."
+                       Foreground="#A8BDD8"
+                       TextWrapping="Wrap" />
+          </StackPanel>
+        </Border>
+      </StackPanel>
+    </Grid>
+  </Border>
+</UserControl>

--- a/samples/Effector.Compiz.Sample.App/Pages/ContactPage.axaml.cs
+++ b/samples/Effector.Compiz.Sample.App/Pages/ContactPage.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Effector.Compiz.Sample.App.Pages;
+
+public partial class ContactPage : UserControl
+{
+    public ContactPage()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/Effector.Compiz.Sample.App/Pages/HomePage.axaml
+++ b/samples/Effector.Compiz.Sample.App/Pages/HomePage.axaml
@@ -1,0 +1,98 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Effector.Compiz.Sample.App.Pages.HomePage">
+  <Border Background="#FF0D1424"
+          Padding="48,42">
+    <Grid RowDefinitions="Auto,Auto,Auto,*,Auto"
+          RowSpacing="22">
+      <Border Width="116"
+              Height="4"
+              CornerRadius="999"
+              Background="#8B5CF6" />
+
+      <TextBlock Grid.Row="1"
+                 Text="Shader-driven page transitions&#x0a;for Avalonia and Effector"
+                 FontSize="48"
+                 FontWeight="SemiBold"
+                 Foreground="#F8FBFF" />
+
+      <StackPanel Grid.Row="2"
+                  Spacing="14"
+                  MaxWidth="760">
+        <TextBlock Text="This sample recreates the compiz-web idea on the desktop: each navigation captures the current and next page, feeds both bitmaps into an Effector shader effect, and composites the result with SkiaSharp."
+                   FontSize="18"
+                   Foreground="#C0D1E8"
+                   TextWrapping="Wrap" />
+        <TextBlock Text="Use the picker in the title bar to switch between dissolve, burn, cube, wobbly, genie, magnetic, or random mode. Click anywhere on a route button to steer the transition origin."
+                   Foreground="#9CB2CC"
+                   TextWrapping="Wrap" />
+      </StackPanel>
+
+      <Grid Grid.Row="3"
+            ColumnDefinitions="1.35*,0.95*"
+            ColumnSpacing="28">
+        <StackPanel Spacing="18">
+          <Border Padding="20"
+                  CornerRadius="24"
+                  Background="#141C2E">
+            <StackPanel Spacing="10">
+              <TextBlock Text="Built on Effector's public effect API"
+                         FontSize="24"
+                         FontWeight="SemiBold"
+                         Foreground="#F5FAFF" />
+              <TextBlock Text="The transition surface is still just a normal Avalonia visual with a single `Visual.Effect`. Extra shader inputs are supplied through render-safe image handles rather than a custom renderer."
+                         Foreground="#A6BCD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+
+          <StackPanel Orientation="Horizontal"
+                      Spacing="12">
+            <Button Tag="/work"
+                    Padding="18,12"
+                    Background="#335B8CFF"
+                    Foreground="White"
+                    FontWeight="SemiBold"
+                    Content="Explore the effects" />
+            <Button Tag="/about"
+                    Padding="18,12"
+                    Background="#1EFFFFFF"
+                    Foreground="#E8F1FF"
+                    Content="How it works" />
+          </StackPanel>
+        </StackPanel>
+
+        <Border Grid.Column="1"
+                Padding="24"
+                CornerRadius="28"
+                Background="#12192A"
+                BorderBrush="#1FFFFFFF"
+                BorderThickness="1">
+          <StackPanel Spacing="14">
+            <TextBlock Text="What you get"
+                       FontSize="22"
+                       FontWeight="SemiBold"
+                       Foreground="#F6FBFF" />
+            <TextBlock Text="1. Page-to-page captures routed through Effector shaders"
+                       Foreground="#C7D6EA" />
+            <TextBlock Text="2. CPU fallback renderers for the same transition catalog"
+                       Foreground="#C7D6EA" />
+            <TextBlock Text="3. Click-position-aware origins and direction changes"
+                       Foreground="#C7D6EA" />
+            <TextBlock Text="4. Real Avalonia controls, forms, and layouts between transitions"
+                       Foreground="#C7D6EA" />
+          </StackPanel>
+        </Border>
+      </Grid>
+
+      <Border Grid.Row="4"
+              Padding="14,10"
+              Background="#12192A"
+              CornerRadius="999"
+              HorizontalAlignment="Left">
+        <TextBlock Text="Inspired by compiz-web, re-authored for Avalonia + Effector + SkiaSharp."
+                   Foreground="#9CB2CC" />
+      </Border>
+    </Grid>
+  </Border>
+</UserControl>

--- a/samples/Effector.Compiz.Sample.App/Pages/HomePage.axaml.cs
+++ b/samples/Effector.Compiz.Sample.App/Pages/HomePage.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Effector.Compiz.Sample.App.Pages;
+
+public partial class HomePage : UserControl
+{
+    public HomePage()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/Effector.Compiz.Sample.App/Pages/WorkPage.axaml
+++ b/samples/Effector.Compiz.Sample.App/Pages/WorkPage.axaml
@@ -1,0 +1,137 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Effector.Compiz.Sample.App.Pages.WorkPage">
+  <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Auto">
+    <Border Background="#FF111827"
+            Padding="48,42">
+      <Grid RowDefinitions="Auto,Auto,Auto"
+            RowSpacing="22">
+        <Border Width="116"
+                Height="4"
+                CornerRadius="999"
+                Background="#F59E0B" />
+
+        <StackPanel Grid.Row="1"
+                    Spacing="14"
+                    MaxWidth="760">
+          <TextBlock Text="Transition catalog"
+                     FontSize="46"
+                     FontWeight="SemiBold"
+                     Foreground="#F8FBFF" />
+          <TextBlock Text="Each option below is a dedicated Effector shader/fallback pair fed by two captured page images. Pick one in the title bar, then click another route to watch it run."
+                     FontSize="18"
+                     Foreground="#C0D1E8"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+
+        <WrapPanel Grid.Row="2"
+                   ItemWidth="300"
+                   Orientation="Horizontal"
+                   HorizontalAlignment="Stretch">
+          <Border Width="288"
+                  Margin="0,0,20,20"
+                  Padding="18"
+                  CornerRadius="24"
+                  Background="#141E33">
+            <StackPanel Spacing="10">
+              <Border Width="14" Height="14" Background="#8B5CF6" CornerRadius="999" />
+              <TextBlock Text="Dissolve"
+                         FontSize="22"
+                         FontWeight="SemiBold"
+                         Foreground="#F7FBFF" />
+              <TextBlock Text="Layered noise carves the old page away while a warm edge rolls out from the click point."
+                         Foreground="#A6BCD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+
+          <Border Width="288"
+                  Margin="0,0,20,20"
+                  Padding="18"
+                  CornerRadius="24"
+                  Background="#141E33">
+            <StackPanel Spacing="10">
+              <Border Width="14" Height="14" Background="#F97316" CornerRadius="999" />
+              <TextBlock Text="Burn"
+                         FontSize="22"
+                         FontWeight="SemiBold"
+                         Foreground="#F7FBFF" />
+              <TextBlock Text="Ember, char, and smoke layers create a fiery reveal before the destination page settles into view."
+                         Foreground="#A6BCD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+
+          <Border Width="288"
+                  Margin="0,0,20,20"
+                  Padding="18"
+                  CornerRadius="24"
+                  Background="#141E33">
+            <StackPanel Spacing="10">
+              <Border Width="14" Height="14" Background="#F59E0B" CornerRadius="999" />
+              <TextBlock Text="Cube"
+                         FontSize="22"
+                         FontWeight="SemiBold"
+                         Foreground="#F7FBFF" />
+              <TextBlock Text="A directional turn darkens the outgoing face and brings the new face in from the opposite edge."
+                         Foreground="#A6BCD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+
+          <Border Width="288"
+                  Margin="0,0,20,20"
+                  Padding="18"
+                  CornerRadius="24"
+                  Background="#141E33">
+            <StackPanel Spacing="10">
+              <Border Width="14" Height="14" Background="#6366F1" CornerRadius="999" />
+              <TextBlock Text="Wobbly"
+                         FontSize="22"
+                         FontWeight="SemiBold"
+                         Foreground="#F7FBFF" />
+              <TextBlock Text="A springy ripple distorts both pages while the reveal front chases the expanding ring."
+                         Foreground="#A6BCD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+
+          <Border Width="288"
+                  Margin="0,0,20,20"
+                  Padding="18"
+                  CornerRadius="24"
+                  Background="#141E33">
+            <StackPanel Spacing="10">
+              <Border Width="14" Height="14" Background="#10B981" CornerRadius="999" />
+              <TextBlock Text="Genie"
+                         FontSize="22"
+                         FontWeight="SemiBold"
+                         Foreground="#F7FBFF" />
+              <TextBlock Text="The active page compresses toward the click target while the destination page fades up beneath it."
+                         Foreground="#A6BCD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+
+          <Border Width="288"
+                  Margin="0,0,20,20"
+                  Padding="18"
+                  CornerRadius="24"
+                  Background="#141E33">
+            <StackPanel Spacing="10">
+              <Border Width="14" Height="14" Background="#EC4899" CornerRadius="999" />
+              <TextBlock Text="Magnetic"
+                         FontSize="22"
+                         FontWeight="SemiBold"
+                         Foreground="#F7FBFF" />
+              <TextBlock Text="Pixels pull toward a focus point with jitter and sparks before the destination page reassembles."
+                         Foreground="#A6BCD8"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+        </WrapPanel>
+      </Grid>
+    </Border>
+  </ScrollViewer>
+</UserControl>

--- a/samples/Effector.Compiz.Sample.App/Pages/WorkPage.axaml.cs
+++ b/samples/Effector.Compiz.Sample.App/Pages/WorkPage.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Effector.Compiz.Sample.App.Pages;
+
+public partial class WorkPage : UserControl
+{
+    public WorkPage()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/Effector.Compiz.Sample.App/Program.cs
+++ b/samples/Effector.Compiz.Sample.App/Program.cs
@@ -1,0 +1,15 @@
+using Avalonia;
+
+namespace Effector.Compiz.Sample.App;
+
+internal static class Program
+{
+    [System.STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}

--- a/samples/Effector.Compiz.Sample.App/TransitionPreferenceStore.cs
+++ b/samples/Effector.Compiz.Sample.App/TransitionPreferenceStore.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Effector.Compiz.Sample.App;
+
+internal static class TransitionPreferenceStore
+{
+    private static readonly string DirectoryPath =
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Effector");
+
+    private static readonly string FilePath =
+        Path.Combine(DirectoryPath, "compiz-transition-effect.txt");
+
+    public static string? Load()
+    {
+        if (!File.Exists(FilePath))
+        {
+            return null;
+        }
+
+        var value = File.ReadAllText(FilePath, Encoding.UTF8).Trim();
+        return value.Length == 0 ? null : value;
+    }
+
+    public static void Save(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(DirectoryPath);
+        File.WriteAllText(FilePath, value.Trim(), Encoding.UTF8);
+    }
+}

--- a/samples/Effector.Compiz.Sample.Effects/CompizTransitionCatalog.cs
+++ b/samples/Effector.Compiz.Sample.Effects/CompizTransitionCatalog.cs
@@ -1,0 +1,97 @@
+using System;
+using Avalonia.Media;
+
+namespace Effector.Compiz.Sample.Effects;
+
+public enum CompizTransitionKind
+{
+    Dissolve,
+    Burn,
+    Cube,
+    Wobbly,
+    Genie,
+    Magnetic
+}
+
+public sealed record CompizTransitionDescriptor(
+    CompizTransitionKind Kind,
+    string Id,
+    string DisplayName,
+    TimeSpan Duration,
+    Color Accent,
+    string Description);
+
+public static class CompizTransitionCatalog
+{
+    public static readonly CompizTransitionDescriptor[] All =
+    {
+        new(
+            CompizTransitionKind.Dissolve,
+            "dissolve",
+            "Dissolve",
+            TimeSpan.FromMilliseconds(1000d),
+            Color.Parse("#8B5CF6"),
+            "Organic noise sweep with a warm edge that reveals the next page from the click point outward."),
+        new(
+            CompizTransitionKind.Burn,
+            "burn",
+            "Burn",
+            TimeSpan.FromMilliseconds(1400d),
+            Color.Parse("#F97316"),
+            "Heat, ember, and smoke layers consume the old page before the new one breaks through."),
+        new(
+            CompizTransitionKind.Cube,
+            "cube",
+            "Cube",
+            TimeSpan.FromMilliseconds(1200d),
+            Color.Parse("#F59E0B"),
+            "A full-frame cube turn ray-casts the outgoing and incoming faces based on which side of the window you click."),
+        new(
+            CompizTransitionKind.Wobbly,
+            "wobbly",
+            "Wobbly",
+            TimeSpan.FromMilliseconds(1200d),
+            Color.Parse("#6366F1"),
+            "A click-driven wave front distorts both pages while the new one chases the ripple."),
+        new(
+            CompizTransitionKind.Genie,
+            "genie",
+            "Genie",
+            TimeSpan.FromMilliseconds(800d),
+            Color.Parse("#10B981"),
+            "The current page is squeezed toward a focus point while the next page settles in behind it."),
+        new(
+            CompizTransitionKind.Magnetic,
+            "magnetic",
+            "Magnetic",
+            TimeSpan.FromMilliseconds(1200d),
+            Color.Parse("#EC4899"),
+            "Pixels pull toward the click point, then reassemble into the destination page with an electric glow.")
+    };
+
+    public static CompizTransitionDescriptor Get(CompizTransitionKind kind)
+    {
+        foreach (var descriptor in All)
+        {
+            if (descriptor.Kind == kind)
+            {
+                return descriptor;
+            }
+        }
+
+        return All[0];
+    }
+
+    public static CompizTransitionDescriptor Get(string id)
+    {
+        foreach (var descriptor in All)
+        {
+            if (string.Equals(descriptor.Id, id, StringComparison.OrdinalIgnoreCase))
+            {
+                return descriptor;
+            }
+        }
+
+        return All[0];
+    }
+}

--- a/samples/Effector.Compiz.Sample.Effects/CompizTransitionEffect.cs
+++ b/samples/Effector.Compiz.Sample.Effects/CompizTransitionEffect.cs
@@ -1,0 +1,863 @@
+using System;
+using Avalonia;
+using Effector;
+using SkiaSharp;
+
+namespace Effector.Compiz.Sample.Effects;
+
+[SkiaEffect(typeof(CompizTransitionEffectFactory))]
+public sealed class CompizTransitionEffect : SkiaEffectBase
+{
+    public static readonly StyledProperty<CompizTransitionKind> KindProperty =
+        AvaloniaProperty.Register<CompizTransitionEffect, CompizTransitionKind>(nameof(Kind), CompizTransitionKind.Dissolve);
+
+    public static readonly StyledProperty<SkiaShaderImageHandle> FromImageProperty =
+        AvaloniaProperty.Register<CompizTransitionEffect, SkiaShaderImageHandle>(nameof(FromImage));
+
+    public static readonly StyledProperty<SkiaShaderImageHandle> ToImageProperty =
+        AvaloniaProperty.Register<CompizTransitionEffect, SkiaShaderImageHandle>(nameof(ToImage));
+
+    public static readonly StyledProperty<double> ProgressProperty =
+        AvaloniaProperty.Register<CompizTransitionEffect, double>(nameof(Progress), 0d);
+
+    public static readonly StyledProperty<double> TimeProperty =
+        AvaloniaProperty.Register<CompizTransitionEffect, double>(nameof(Time), 0d);
+
+    public static readonly StyledProperty<double> ClickXProperty =
+        AvaloniaProperty.Register<CompizTransitionEffect, double>(nameof(ClickX), 0.5d);
+
+    public static readonly StyledProperty<double> ClickYProperty =
+        AvaloniaProperty.Register<CompizTransitionEffect, double>(nameof(ClickY), 0.5d);
+
+    static CompizTransitionEffect()
+    {
+        AffectsRender<CompizTransitionEffect>(
+            KindProperty,
+            FromImageProperty,
+            ToImageProperty,
+            ProgressProperty,
+            TimeProperty,
+            ClickXProperty,
+            ClickYProperty);
+    }
+
+    public CompizTransitionKind Kind
+    {
+        get => GetValue(KindProperty);
+        set => SetValue(KindProperty, value);
+    }
+
+    public SkiaShaderImageHandle FromImage
+    {
+        get => GetValue(FromImageProperty);
+        set => SetValue(FromImageProperty, value);
+    }
+
+    public SkiaShaderImageHandle ToImage
+    {
+        get => GetValue(ToImageProperty);
+        set => SetValue(ToImageProperty, value);
+    }
+
+    public double Progress
+    {
+        get => GetValue(ProgressProperty);
+        set => SetValue(ProgressProperty, value);
+    }
+
+    public double Time
+    {
+        get => GetValue(TimeProperty);
+        set => SetValue(TimeProperty, value);
+    }
+
+    public double ClickX
+    {
+        get => GetValue(ClickXProperty);
+        set => SetValue(ClickXProperty, value);
+    }
+
+    public double ClickY
+    {
+        get => GetValue(ClickYProperty);
+        set => SetValue(ClickYProperty, value);
+    }
+}
+
+public sealed class CompizTransitionEffectFactory :
+    ISkiaEffectFactory<CompizTransitionEffect>,
+    ISkiaShaderEffectFactory<CompizTransitionEffect>,
+    ISkiaEffectValueFactory,
+    ISkiaShaderEffectValueFactory
+{
+    private const int KindIndex = 0;
+    private const int FromImageIndex = 1;
+    private const int ToImageIndex = 2;
+    private const int ProgressIndex = 3;
+    private const int TimeIndex = 4;
+    private const int ClickXIndex = 5;
+    private const int ClickYIndex = 6;
+
+    private const string DissolveShaderSource =
+        """
+        uniform shader fromImage;
+        uniform shader toImage;
+        uniform float width;
+        uniform float height;
+        uniform float progress;
+        uniform float time;
+        uniform float clickX;
+        uniform float clickY;
+
+        float hash(float2 p) {
+            return fract(sin(dot(p, float2(127.1, 311.7))) * 43758.5453);
+        }
+
+        float noise(float2 p) {
+            float2 cell = floor(p);
+            float2 local = fract(p);
+            local = local * local * (3.0 - (2.0 * local));
+            float a = hash(cell);
+            float b = hash(cell + float2(1.0, 0.0));
+            float c = hash(cell + float2(0.0, 1.0));
+            float d = hash(cell + float2(1.0, 1.0));
+            return mix(mix(a, b, local.x), mix(c, d, local.x), local.y);
+        }
+
+        float layeredNoise(float2 p) {
+            float value = 0.0;
+            float amplitude = 0.6;
+            for (int i = 0; i < 3; i++) {
+                value += noise(p) * amplitude;
+                p = (p * 2.07) + float2(9.1, -5.3);
+                amplitude *= 0.5;
+            }
+            return value;
+        }
+
+        half4 main(float2 coord) {
+            float safeWidth = max(width, 1.0);
+            float safeHeight = max(height, 1.0);
+            float2 uv = float2(coord.x / safeWidth, coord.y / safeHeight);
+            float2 click = float2(clickX, clickY);
+            float distanceField = distance(uv, click);
+            float pattern = layeredNoise((uv * 6.0) + float2(time * 0.11, -time * 0.07));
+            float frontier = (progress * 1.35) - (distanceField * 0.42);
+            float reveal = smoothstep(frontier - 0.1, frontier + 0.08, pattern);
+            float glow = smoothstep(frontier - 0.02, frontier + 0.02, pattern) -
+                         smoothstep(frontier + 0.02, frontier + 0.1, pattern);
+
+            half4 fromColor = fromImage.eval(coord);
+            half4 toColor = toImage.eval(coord);
+            half3 rgb = mix(fromColor.rgb, toColor.rgb, half(reveal));
+            rgb += half3(1.0, 0.58, 0.18) * half(glow * 0.3);
+            return half4(clamp(rgb, 0.0, 1.0), 1.0);
+        }
+        """;
+
+    private const string BurnShaderSource =
+        """
+        uniform shader fromImage;
+        uniform shader toImage;
+        uniform float width;
+        uniform float height;
+        uniform float progress;
+        uniform float time;
+        uniform float clickX;
+        uniform float clickY;
+
+        float hash(float2 p) {
+            return fract(sin(dot(p, float2(91.7, 283.3))) * 43758.5453);
+        }
+
+        float noise(float2 p) {
+            float2 cell = floor(p);
+            float2 local = fract(p);
+            local = local * local * (3.0 - (2.0 * local));
+            float a = hash(cell);
+            float b = hash(cell + float2(1.0, 0.0));
+            float c = hash(cell + float2(0.0, 1.0));
+            float d = hash(cell + float2(1.0, 1.0));
+            return mix(mix(a, b, local.x), mix(c, d, local.x), local.y);
+        }
+
+        float fbm(float2 p) {
+            float value = 0.0;
+            float amplitude = 0.55;
+            for (int i = 0; i < 4; i++) {
+                value += noise(p) * amplitude;
+                p = (p * 2.03) + float2(7.4, -6.8);
+                amplitude *= 0.52;
+            }
+            return value;
+        }
+
+        half4 main(float2 coord) {
+            float safeWidth = max(width, 1.0);
+            float safeHeight = max(height, 1.0);
+            float2 uv = float2(coord.x / safeWidth, coord.y / safeHeight);
+            float2 click = float2(clickX, clickY);
+            float distanceField = distance(uv, click);
+            float field = fbm((uv * 7.0) + float2(time * 0.18, -time * 0.09));
+            float front = (progress * 1.7) - (distanceField * 1.15) + (field * 0.28);
+            float ember = clamp(1.0 - abs(front / 0.12), 0.0, 1.0);
+            float charAmount = smoothstep(-0.02, 0.24, front) * (1.0 - smoothstep(0.24, 0.48, front));
+            float reveal = smoothstep(0.18, 0.42, front);
+            float smoke = smoothstep(-0.34, -0.06, front) * (1.0 - smoothstep(-0.06, 0.12, front));
+
+            float distortion = ember * (field - 0.5) * 22.0;
+            half4 fromColor = fromImage.eval(coord + float2(distortion, distortion * 0.35));
+            half4 toColor = toImage.eval(coord);
+
+            half3 rgb = fromColor.rgb;
+            rgb = mix(rgb, fromColor.rgb * half3(0.2, 0.08, 0.03), half(charAmount));
+            rgb = mix(rgb, toColor.rgb, half(reveal));
+            rgb += half3(1.0, 0.64, 0.18) * half(ember * 0.72);
+            rgb += half3(0.15, 0.12, 0.11) * half(smoke * 0.22);
+            return half4(clamp(rgb, 0.0, 1.0), 1.0);
+        }
+        """;
+
+    private const string CubeShaderSource =
+        """
+        uniform shader fromImage;
+        uniform shader toImage;
+        uniform float width;
+        uniform float height;
+        uniform float progress;
+        uniform float time;
+        uniform float clickX;
+        uniform float clickY;
+
+        const float PI = 3.14159265359;
+
+        half4 main(float2 coord) {
+            float safeWidth = max(width, 1.0);
+            float safeHeight = max(height, 1.0);
+            float aspect = safeWidth / safeHeight;
+            float direction = clickX > 0.5 ? 1.0 : -1.0;
+            float halfWidth = aspect;
+            float halfHeight = 1.0;
+            float focalLength = 3.0;
+            float baseCameraDistance = focalLength - halfWidth;
+            float turn = progress * progress * (3.0 - (2.0 * progress));
+            float angle = turn * PI * 0.5 * direction;
+            float cosine = cos(angle);
+            float sine = sin(angle);
+            float cameraPullback = sin(turn * PI);
+            float cameraDistance = baseCameraDistance + (1.5 * cameraPullback);
+
+            float2 screen = float2(
+                ((coord.x / safeWidth) * 2.0) - 1.0,
+                ((coord.y / safeHeight) * 2.0) - 1.0);
+            screen.x *= aspect;
+
+            float3 rayOrigin = float3(0.0, 0.0, cameraDistance);
+            float3 rayDirection = normalize(float3(screen.x, screen.y, -focalLength));
+            float3 rotatedDirection = float3(
+                (rayDirection.x * cosine) - (rayDirection.z * sine),
+                rayDirection.y,
+                (rayDirection.x * sine) + (rayDirection.z * cosine));
+            float3 rotatedOrigin = float3(
+                (rayOrigin.x * cosine) - (rayOrigin.z * sine),
+                rayOrigin.y,
+                (rayOrigin.x * sine) + (rayOrigin.z * cosine));
+
+            half3 rgb = half3(0.0);
+            float nearestHit = 1e10;
+
+            if (abs(rotatedDirection.z) > 0.001) {
+                float hitDistance = (-halfWidth - rotatedOrigin.z) / rotatedDirection.z;
+                if (hitDistance > 0.0 && hitDistance < nearestHit) {
+                    float3 hitPoint = rotatedOrigin + (hitDistance * rotatedDirection);
+                    if (abs(hitPoint.x) <= halfWidth && abs(hitPoint.y) <= halfHeight) {
+                        nearestHit = hitDistance;
+                        float2 sampleUv = float2(
+                            ((hitPoint.x / halfWidth) * 0.5) + 0.5,
+                            (hitPoint.y * 0.5) + 0.5);
+                        half4 sample = fromImage.eval(float2(sampleUv.x * safeWidth, sampleUv.y * safeHeight));
+                        float facing = max(0.0, cosine);
+                        rgb = sample.rgb * half(0.25 + (0.75 * facing));
+                    }
+                }
+            }
+
+            if (direction > 0.0 && abs(rotatedDirection.x) > 0.001) {
+                float hitDistance = (halfWidth - rotatedOrigin.x) / rotatedDirection.x;
+                if (hitDistance > 0.0 && hitDistance < nearestHit) {
+                    float3 hitPoint = rotatedOrigin + (hitDistance * rotatedDirection);
+                    if (abs(hitPoint.z) <= halfWidth && abs(hitPoint.y) <= halfHeight) {
+                        nearestHit = hitDistance;
+                        float2 sampleUv = float2(
+                            ((hitPoint.z / halfWidth) * 0.5) + 0.5,
+                            (hitPoint.y * 0.5) + 0.5);
+                        half4 sample = toImage.eval(float2(sampleUv.x * safeWidth, sampleUv.y * safeHeight));
+                        float facing = max(0.0, sine * direction);
+                        rgb = sample.rgb * half(0.25 + (0.75 * facing));
+                    }
+                }
+            }
+
+            if (direction < 0.0 && abs(rotatedDirection.x) > 0.001) {
+                float hitDistance = (-halfWidth - rotatedOrigin.x) / rotatedDirection.x;
+                if (hitDistance > 0.0 && hitDistance < nearestHit) {
+                    float3 hitPoint = rotatedOrigin + (hitDistance * rotatedDirection);
+                    if (abs(hitPoint.z) <= halfWidth && abs(hitPoint.y) <= halfHeight) {
+                        float2 sampleUv = float2(
+                            ((-hitPoint.z / halfWidth) * 0.5) + 0.5,
+                            (hitPoint.y * 0.5) + 0.5);
+                        half4 sample = toImage.eval(float2(sampleUv.x * safeWidth, sampleUv.y * safeHeight));
+                        float facing = max(0.0, -sine * direction);
+                        rgb = sample.rgb * half(0.25 + (0.75 * facing));
+                    }
+                }
+            }
+
+            return half4(clamp(rgb, 0.0, 1.0), 1.0);
+        }
+        """;
+
+    private const string WobblyShaderSource =
+        """
+        uniform shader fromImage;
+        uniform shader toImage;
+        uniform float width;
+        uniform float height;
+        uniform float progress;
+        uniform float time;
+        uniform float clickX;
+        uniform float clickY;
+
+        half4 main(float2 coord) {
+            float safeWidth = max(width, 1.0);
+            float safeHeight = max(height, 1.0);
+            float2 uv = float2(coord.x / safeWidth, coord.y / safeHeight);
+            float2 click = float2(clickX, clickY);
+            float2 direction = normalize((uv - click) + float2(0.0001, 0.0001));
+            float distanceField = distance(uv, click);
+            float front = (progress * 1.35) - distanceField;
+            float ring = exp(-pow(front * 18.0, 2.0));
+            float oscillation = sin((distanceField * 44.0) - (time * 7.0));
+            float displacement = ring * (1.0 - progress) * (18.0 + (oscillation * 7.0));
+            float2 offset = direction * displacement;
+
+            half4 fromColor = fromImage.eval(coord + offset);
+            half4 toColor = toImage.eval(coord - (offset * 0.35));
+            float reveal = smoothstep(-0.03, 0.16, front);
+
+            half3 rgb = mix(fromColor.rgb, toColor.rgb, half(reveal));
+            rgb += half3(0.26, 0.42, 0.92) * half(ring * (1.0 - progress) * 0.22);
+            return half4(clamp(rgb, 0.0, 1.0), 1.0);
+        }
+        """;
+
+    private const string GenieShaderSource =
+        """
+        uniform shader fromImage;
+        uniform shader toImage;
+        uniform float width;
+        uniform float height;
+        uniform float progress;
+        uniform float time;
+        uniform float clickX;
+        uniform float clickY;
+
+        half4 main(float2 coord) {
+            float safeWidth = max(width, 1.0);
+            float safeHeight = max(height, 1.0);
+            float2 click = float2(clickX * safeWidth, clickY * safeHeight);
+            float t = progress * progress;
+            float rowInfluence = clamp(1.0 - abs((coord.y / safeHeight) - clickY), 0.0, 1.0);
+            float squeeze = max(1.0 - (t * (0.76 + (rowInfluence * 0.24))), 0.05);
+            float centerX = mix(coord.x, click.x, t);
+            float sourceX = ((coord.x - centerX) / squeeze) + click.x;
+            float sourceY = mix(coord.y, click.y, t * t);
+            float curve = sin((coord.y / safeHeight) * 3.14159265) * (1.0 - progress) * 24.0;
+            sourceX += curve * sign(coord.x - click.x);
+
+            bool valid = sourceX >= 0.0 && sourceX <= safeWidth && sourceY >= 0.0 && sourceY <= safeHeight;
+            half4 fromColor = valid ? fromImage.eval(float2(sourceX, sourceY)) : half4(0.0);
+            half4 toColor = toImage.eval(coord);
+            float reveal = smoothstep(0.34, 1.0, progress);
+
+            half3 rgb = mix(fromColor.rgb, toColor.rgb, half(reveal));
+            float glow = exp(-distance(coord, click) / max(min(safeWidth, safeHeight) * 0.18, 1.0)) * progress * 0.18;
+            rgb += half3(0.52, 0.34, 0.92) * half(glow);
+            return half4(clamp(rgb, 0.0, 1.0), 1.0);
+        }
+        """;
+
+    private const string MagneticShaderSource =
+        """
+        uniform shader fromImage;
+        uniform shader toImage;
+        uniform float width;
+        uniform float height;
+        uniform float progress;
+        uniform float time;
+        uniform float clickX;
+        uniform float clickY;
+
+        float hash(float2 p) {
+            return fract(sin(dot(p, float2(73.1, 187.7))) * 43758.5453);
+        }
+
+        half4 main(float2 coord) {
+            float safeWidth = max(width, 1.0);
+            float safeHeight = max(height, 1.0);
+            float2 uv = float2(coord.x / safeWidth, coord.y / safeHeight);
+            float2 click = float2(clickX, clickY);
+            float scatter = smoothstep(0.0, 0.5, progress);
+            float assemble = smoothstep(0.5, 1.0, progress);
+            float2 toClick = click - uv;
+            float distanceField = length(toClick);
+            float2 direction = normalize(toClick + float2(0.001, 0.001));
+            float pull = exp(-(distanceField * distanceField) * 4.0);
+            float scatterAmount = scatter * pull * 0.4;
+            float turbulence = (hash((uv * 100.0) + time) - 0.5) * 0.04 * scatter;
+
+            float2 uvR = clamp(uv + (direction * (scatterAmount * 1.15)) + float2(turbulence, turbulence), 0.0, 1.0);
+            float2 uvG = clamp(uv + (direction * scatterAmount) + float2(turbulence, turbulence), 0.0, 1.0);
+            float2 uvB = clamp(uv + (direction * (scatterAmount * 0.85)) + float2(turbulence, turbulence), 0.0, 1.0);
+
+            half3 scatteredFrom = half3(
+                fromImage.eval(float2(uvR.x * safeWidth, uvR.y * safeHeight)).r,
+                fromImage.eval(float2(uvG.x * safeWidth, uvG.y * safeHeight)).g,
+                fromImage.eval(float2(uvB.x * safeWidth, uvB.y * safeHeight)).b);
+
+            half4 toColor = toImage.eval(coord);
+            float assembleRadius = assemble * 2.0;
+            float reveal = 1.0 - smoothstep(assembleRadius - 0.3, assembleRadius, distanceField);
+            float cellNoise = hash(floor((uv * float2(safeWidth, safeHeight)) / 4.0));
+            float dissolve = (1.0 - scatter) * step(scatter * 1.2, cellNoise + 0.2);
+
+            half3 rgb = scatteredFrom * half(dissolve);
+            rgb = mix(rgb, toColor.rgb, half(reveal));
+
+            float energy = exp(-(distanceField * distanceField) * 10.0) * ((sin(time * 8.0) * 0.5) + 0.5);
+            float energyAmount = scatter * (1.0 - assemble);
+            rgb += half3(0.3, 0.5, 1.0) * half(energy * energyAmount * 0.4);
+
+            float edgeGlow = smoothstep(assembleRadius - 0.05, assembleRadius, distanceField) *
+                             (1.0 - smoothstep(assembleRadius, assembleRadius + 0.05, distanceField));
+            rgb += half3(0.5, 0.7, 1.0) * half(edgeGlow * 0.8);
+            return half4(clamp(rgb, 0.0, 1.0), 1.0);
+        }
+        """;
+
+    public Thickness GetPadding(CompizTransitionEffect effect) => default;
+
+    public SKImageFilter? CreateFilter(CompizTransitionEffect effect, SkiaEffectContext context) => null;
+
+    public Thickness GetPadding(object[] values) => default;
+
+    public SKImageFilter? CreateFilter(object[] values, SkiaEffectContext context) => null;
+
+    public SkiaShaderEffect? CreateShaderEffect(CompizTransitionEffect effect, SkiaShaderEffectContext context) =>
+        CreateShaderEffect(
+            new object[]
+            {
+                effect.Kind,
+                effect.FromImage,
+                effect.ToImage,
+                effect.Progress,
+                effect.Time,
+                effect.ClickX,
+                effect.ClickY
+            },
+            context);
+
+    public SkiaShaderEffect? CreateShaderEffect(object[] values, SkiaShaderEffectContext context)
+    {
+        if (!TryAcquireImages(values, out var fromLease, out var toLease))
+        {
+            return null;
+        }
+
+        try
+        {
+            return ((CompizTransitionKind)values[KindIndex]) switch
+            {
+                CompizTransitionKind.Burn => CreateTransitionShader(values, context, fromLease, toLease, BurnShaderSource, DrawBurnFallback),
+                CompizTransitionKind.Cube => CreateTransitionShader(values, context, fromLease, toLease, CubeShaderSource, DrawCubeFallback),
+                CompizTransitionKind.Wobbly => CreateTransitionShader(values, context, fromLease, toLease, WobblyShaderSource, DrawWobblyFallback),
+                CompizTransitionKind.Genie => CreateTransitionShader(values, context, fromLease, toLease, GenieShaderSource, DrawGenieFallback),
+                CompizTransitionKind.Magnetic => CreateTransitionShader(values, context, fromLease, toLease, MagneticShaderSource, DrawMagneticFallback),
+                _ => CreateTransitionShader(values, context, fromLease, toLease, DissolveShaderSource, DrawDissolveFallback)
+            };
+        }
+        catch
+        {
+            fromLease.Dispose();
+            toLease.Dispose();
+            throw;
+        }
+    }
+
+    private delegate void TransitionFallbackRenderer(
+        SKCanvas canvas,
+        SKRect rect,
+        SKImage fromImage,
+        SKImage toImage,
+        float progress,
+        float time,
+        SKPoint click);
+
+    private static SkiaShaderEffect CreateTransitionShader(
+        object[] values,
+        SkiaShaderEffectContext context,
+        SkiaShaderImageLease fromLease,
+        SkiaShaderImageLease toLease,
+        string shaderSource,
+        TransitionFallbackRenderer fallbackRenderer)
+    {
+        var progress = Clamp01((double)values[ProgressIndex]);
+        var time = Math.Max(0f, (float)(double)values[TimeIndex]);
+        var click = GetClick(values);
+
+        return SkiaRuntimeShaderBuilder.Create(
+            shaderSource,
+            context,
+            uniforms =>
+            {
+                uniforms.Add("width", context.EffectBounds.Width);
+                uniforms.Add("height", context.EffectBounds.Height);
+                uniforms.Add("progress", progress);
+                uniforms.Add("time", time);
+                uniforms.Add("clickX", click.X);
+                uniforms.Add("clickY", click.Y);
+            },
+            fallbackRenderer: (canvas, _, rect) =>
+            {
+                fallbackRenderer(canvas, rect, fromLease.Image, toLease.Image, progress, time, click);
+            },
+            blendMode: SKBlendMode.Src,
+            configureOwnedChildren: (children, _, ownedResources) =>
+            {
+                var fromShader = fromLease.Image.ToShader(SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
+                var toShader = toLease.Image.ToShader(SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
+                children.Add("fromImage", fromShader);
+                children.Add("toImage", toShader);
+                ownedResources.Add(fromShader);
+                ownedResources.Add(toShader);
+            },
+            ownedResources: new IDisposable[] { fromLease, toLease });
+    }
+
+    private static bool TryAcquireImages(object[] values, out SkiaShaderImageLease fromLease, out SkiaShaderImageLease toLease)
+    {
+        fromLease = null!;
+        toLease = null!;
+
+        if (!SkiaShaderImageRegistry.TryAcquire((SkiaShaderImageHandle)values[FromImageIndex], out var from) || from is null)
+        {
+            return false;
+        }
+
+        if (!SkiaShaderImageRegistry.TryAcquire((SkiaShaderImageHandle)values[ToImageIndex], out var to) || to is null)
+        {
+            from.Dispose();
+            return false;
+        }
+
+        fromLease = from;
+        toLease = to;
+        return true;
+    }
+
+    private static SKPoint GetClick(object[] values) =>
+        new(
+            Clamp01((double)values[ClickXIndex]),
+            Clamp01((double)values[ClickYIndex]));
+
+    private static float Clamp01(double value) => (float)Math.Clamp(value, 0d, 1d);
+
+    private static void DrawDissolveFallback(SKCanvas canvas, SKRect rect, SKImage fromImage, SKImage toImage, float progress, float time, SKPoint click)
+    {
+        using var clipScope = new CanvasClipScope(canvas, rect);
+        DrawImage(canvas, fromImage, rect);
+
+        var cellSize = MathF.Max(MathF.Min(rect.Width, rect.Height) / 18f, 14f);
+        var glow = new SKColor(255, 165, 74, 72);
+        for (var y = rect.Top; y < rect.Bottom; y += cellSize)
+        {
+            for (var x = rect.Left; x < rect.Right; x += cellSize)
+            {
+                var cellRect = new SKRect(x, y, MathF.Min(x + cellSize, rect.Right), MathF.Min(y + cellSize, rect.Bottom));
+                var localCenter = new SKPoint(
+                    (cellRect.MidX - rect.Left) / MathF.Max(rect.Width, 1f),
+                    (cellRect.MidY - rect.Top) / MathF.Max(rect.Height, 1f));
+                var threshold = (progress * 1.25f) - (Distance(localCenter, click) * 0.35f);
+                var noise = Hash(cellRect.Left, cellRect.Top, time * 8f);
+                if (noise <= threshold)
+                {
+                    DrawImageCell(canvas, toImage, rect, cellRect);
+                }
+
+                if (MathF.Abs(noise - threshold) < 0.05f)
+                {
+                    using var glowPaint = new SKPaint
+                    {
+                        Color = glow,
+                        IsAntialias = false,
+                        Style = SKPaintStyle.Fill
+                    };
+                    canvas.DrawRect(cellRect, glowPaint);
+                }
+            }
+        }
+    }
+
+    private static void DrawBurnFallback(SKCanvas canvas, SKRect rect, SKImage fromImage, SKImage toImage, float progress, float time, SKPoint click)
+    {
+        using var clipScope = new CanvasClipScope(canvas, rect);
+        DrawImage(canvas, fromImage, rect);
+
+        var clickPoint = ToAbsolutePoint(rect, click);
+        var radius = MathF.Max(rect.Width, rect.Height) * (0.12f + (progress * 1.05f));
+        using var revealPath = new SKPath();
+        revealPath.AddCircle(clickPoint.X, clickPoint.Y, radius);
+        canvas.Save();
+        canvas.ClipPath(revealPath, antialias: true);
+        DrawImage(canvas, toImage, rect);
+        canvas.Restore();
+
+        using var emberPaint = new SKPaint
+        {
+            IsAntialias = true,
+            Shader = SKShader.CreateRadialGradient(
+                clickPoint,
+                MathF.Max(radius * 0.22f, 1f),
+                new[]
+                {
+                    new SKColor(255, 245, 214, 192),
+                    new SKColor(255, 136, 47, 140),
+                    new SKColor(56, 18, 8, 0)
+                },
+                null,
+                SKShaderTileMode.Clamp)
+        };
+        canvas.DrawCircle(clickPoint, radius + 6f, emberPaint);
+
+        using var smokePaint = new SKPaint
+        {
+            IsAntialias = true,
+            Color = new SKColor(33, 26, 24, (byte)(Math.Clamp(1f - progress, 0f, 1f) * 48f))
+        };
+        canvas.DrawCircle(clickPoint, radius * (0.7f + (Hash(clickPoint.X, clickPoint.Y, time * 12f) * 0.18f)), smokePaint);
+    }
+
+    private static void DrawCubeFallback(SKCanvas canvas, SKRect rect, SKImage fromImage, SKImage toImage, float progress, float time, SKPoint click)
+    {
+        using var clipScope = new CanvasClipScope(canvas, rect);
+        using var backgroundPaint = new SKPaint
+        {
+            Color = new SKColor(10, 14, 24, 255),
+            IsAntialias = true
+        };
+        canvas.DrawRect(rect, backgroundPaint);
+
+        var direction = click.X >= 0.5f ? 1f : -1f;
+        var eased = Ease(progress);
+        var outgoingWidth = MathF.Max(rect.Width * (1f - (eased * 0.92f)), rect.Width * 0.08f);
+        var incomingWidth = MathF.Max(rect.Width * (0.08f + (eased * 0.92f)), rect.Width * 0.08f);
+        var fromRect = direction > 0f
+            ? new SKRect(rect.Left, rect.Top + (eased * 14f), rect.Left + outgoingWidth, rect.Bottom - (eased * 14f))
+            : new SKRect(rect.Right - outgoingWidth, rect.Top + (eased * 14f), rect.Right, rect.Bottom - (eased * 14f));
+        var toRect = direction > 0f
+            ? new SKRect(rect.Right - incomingWidth, rect.Top + ((1f - eased) * 14f), rect.Right, rect.Bottom - ((1f - eased) * 14f))
+            : new SKRect(rect.Left, rect.Top + ((1f - eased) * 14f), rect.Left + incomingWidth, rect.Bottom - ((1f - eased) * 14f));
+
+        DrawImage(canvas, fromImage, fromRect);
+        DrawTint(canvas, fromRect, new SKColor(0, 0, 0, (byte)(Math.Clamp(progress, 0f, 1f) * 82f)));
+
+        DrawImage(canvas, toImage, toRect);
+        DrawTint(canvas, toRect, new SKColor(255, 255, 255, (byte)(Math.Clamp(1f - progress, 0f, 1f) * 24f)));
+
+        using var seamPaint = new SKPaint
+        {
+            IsAntialias = true,
+            Shader = SKShader.CreateLinearGradient(
+                new SKPoint(direction > 0f ? fromRect.Right : toRect.Right, rect.Top),
+                new SKPoint(direction > 0f ? toRect.Left : fromRect.Left, rect.Top),
+                new[]
+                {
+                    new SKColor(0, 0, 0, 180),
+                    new SKColor(0, 0, 0, 0)
+                },
+                null,
+                SKShaderTileMode.Clamp)
+        };
+        canvas.DrawRect(rect, seamPaint);
+    }
+
+    private static void DrawWobblyFallback(SKCanvas canvas, SKRect rect, SKImage fromImage, SKImage toImage, float progress, float time, SKPoint click)
+    {
+        using var clipScope = new CanvasClipScope(canvas, rect);
+        DrawImage(canvas, fromImage, rect);
+
+        var clickPoint = ToAbsolutePoint(rect, click);
+        var radius = MathF.Max(rect.Width, rect.Height) * (0.08f + (progress * 0.92f));
+        using var revealPath = new SKPath();
+        revealPath.AddCircle(clickPoint.X, clickPoint.Y, radius + (MathF.Sin(time * 9f) * 10f));
+
+        canvas.Save();
+        canvas.ClipPath(revealPath, antialias: true);
+        DrawImage(canvas, toImage, rect);
+        canvas.Restore();
+
+        using var ringPaint = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = MathF.Max(MathF.Min(rect.Width, rect.Height) * 0.02f, 2f),
+            Color = new SKColor(102, 153, 255, (byte)(Math.Clamp(1f - progress, 0f, 1f) * 160f))
+        };
+        canvas.DrawCircle(clickPoint, radius, ringPaint);
+    }
+
+    private static void DrawGenieFallback(SKCanvas canvas, SKRect rect, SKImage fromImage, SKImage toImage, float progress, float time, SKPoint click)
+    {
+        using var clipScope = new CanvasClipScope(canvas, rect);
+        DrawImage(canvas, toImage, rect);
+
+        var clickPoint = ToAbsolutePoint(rect, click);
+        var eased = progress * progress;
+        var squeezeWidth = MathF.Max(rect.Width * (1f - (eased * 0.9f)), 20f);
+        var squeezeHeight = MathF.Max(rect.Height * (1f - (eased * 0.92f)), 26f);
+        var fromRect = new SKRect(
+            clickPoint.X - (squeezeWidth * 0.5f),
+            clickPoint.Y - (squeezeHeight * 0.5f),
+            clickPoint.X + (squeezeWidth * 0.5f),
+            clickPoint.Y + (squeezeHeight * 0.5f));
+        DrawImage(canvas, fromImage, fromRect, 1f - (progress * 0.68f));
+
+        using var glowPaint = new SKPaint
+        {
+            IsAntialias = true,
+            Shader = SKShader.CreateRadialGradient(
+                clickPoint,
+                MathF.Max(MathF.Min(rect.Width, rect.Height) * 0.18f, 10f),
+                new[]
+                {
+                    new SKColor(155, 105, 255, (byte)(Math.Clamp(progress, 0f, 1f) * 128f)),
+                    new SKColor(155, 105, 255, 0)
+                },
+                null,
+                SKShaderTileMode.Clamp)
+        };
+        canvas.DrawCircle(clickPoint, MathF.Max(MathF.Min(rect.Width, rect.Height) * 0.18f, 10f), glowPaint);
+    }
+
+    private static void DrawMagneticFallback(SKCanvas canvas, SKRect rect, SKImage fromImage, SKImage toImage, float progress, float time, SKPoint click)
+    {
+        using var clipScope = new CanvasClipScope(canvas, rect);
+        var clickPoint = ToAbsolutePoint(rect, click);
+        var scale = 1f - (progress * 0.24f);
+        var fromRect = SKRect.Create(
+            clickPoint.X - ((rect.Width * scale) * 0.5f),
+            clickPoint.Y - ((rect.Height * scale) * 0.5f),
+            rect.Width * scale,
+            rect.Height * scale);
+        DrawImage(canvas, fromImage, fromRect, 1f - (progress * 0.42f));
+
+        var revealRadius = MathF.Max(rect.Width, rect.Height) * MathF.Max(progress - 0.2f, 0f) * 1.1f;
+        if (revealRadius > 0f)
+        {
+            using var revealPath = new SKPath();
+            revealPath.AddCircle(clickPoint.X, clickPoint.Y, revealRadius);
+            canvas.Save();
+            canvas.ClipPath(revealPath, antialias: true);
+            DrawImage(canvas, toImage, rect);
+            canvas.Restore();
+        }
+
+        using var sparkPaint = new SKPaint
+        {
+            IsAntialias = true,
+            Color = new SKColor(90, 160, 255, (byte)(Math.Clamp(1f - progress, 0f, 1f) * 180f))
+        };
+        for (var index = 0; index < 24; index++)
+        {
+            var angle = (index / 24f) * MathF.PI * 2f;
+            var orbit = (18f + (Hash(index, time * 16f, clickPoint.X) * 42f)) * (1f - progress);
+            var particle = new SKPoint(
+                clickPoint.X + (MathF.Cos(angle) * orbit),
+                clickPoint.Y + (MathF.Sin(angle) * orbit));
+            canvas.DrawCircle(particle, 1.6f + (Hash(index, clickPoint.Y, time * 9f) * 2.4f), sparkPaint);
+        }
+    }
+
+    private static void DrawImage(SKCanvas canvas, SKImage image, SKRect rect, float opacity = 1f)
+    {
+        using var paint = new SKPaint
+        {
+            IsAntialias = true,
+            Color = new SKColor(255, 255, 255, (byte)(Math.Clamp(opacity, 0f, 1f) * 255f))
+        };
+        canvas.DrawImage(image, rect, paint);
+    }
+
+    private static void DrawTint(SKCanvas canvas, SKRect rect, SKColor color)
+    {
+        using var paint = new SKPaint
+        {
+            IsAntialias = true,
+            Color = color
+        };
+        canvas.DrawRect(rect, paint);
+    }
+
+    private static void DrawImageCell(SKCanvas canvas, SKImage image, SKRect fullRect, SKRect cellRect)
+    {
+        var sourceRect = new SKRect(
+            ((cellRect.Left - fullRect.Left) / MathF.Max(fullRect.Width, 1f)) * image.Width,
+            ((cellRect.Top - fullRect.Top) / MathF.Max(fullRect.Height, 1f)) * image.Height,
+            ((cellRect.Right - fullRect.Left) / MathF.Max(fullRect.Width, 1f)) * image.Width,
+            ((cellRect.Bottom - fullRect.Top) / MathF.Max(fullRect.Height, 1f)) * image.Height);
+
+        using var paint = new SKPaint
+        {
+            IsAntialias = false
+        };
+        canvas.DrawImage(image, sourceRect, cellRect, paint);
+    }
+
+    private static float Ease(float value) =>
+        value < 0.5f
+            ? 2f * value * value
+            : 1f - (MathF.Pow((-2f * value) + 2f, 2f) * 0.5f);
+
+    private static float Distance(SKPoint left, SKPoint right)
+    {
+        var dx = left.X - right.X;
+        var dy = left.Y - right.Y;
+        return MathF.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    private static SKPoint ToAbsolutePoint(SKRect rect, SKPoint normalized) =>
+        new(
+            rect.Left + (rect.Width * normalized.X),
+            rect.Top + (rect.Height * normalized.Y));
+
+    private static float Hash(float x, float y, float z) =>
+        MathF.Abs(MathF.Sin((x * 12.9898f) + (y * 78.233f) + (z * 37.719f))) % 1f;
+
+    private readonly ref struct CanvasClipScope
+    {
+        private readonly SKCanvas _canvas;
+        private readonly int _restoreCount;
+
+        public CanvasClipScope(SKCanvas canvas, SKRect rect)
+        {
+            _canvas = canvas;
+            _restoreCount = canvas.Save();
+            canvas.ClipRect(rect, antialias: true);
+        }
+
+        public void Dispose()
+        {
+            _canvas.RestoreToCount(_restoreCount);
+        }
+    }
+}

--- a/samples/Effector.Compiz.Sample.Effects/Effector.Compiz.Sample.Effects.csproj
+++ b/samples/Effector.Compiz.Sample.Effects/Effector.Compiz.Sample.Effects.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>Effector.Compiz.Sample.Effects</AssemblyName>
+    <RootNamespace>Effector.Compiz.Sample.Effects</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Effector\Effector.csproj"
+                      AdditionalProperties="GeneratePackageOnBuild=false" />
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="SkiaSharp" />
+  </ItemGroup>
+
+  <Import Project="..\..\src\Effector.Build\buildTransitive\Effector.Build.props" />
+  <Import Project="..\..\src\Effector.Build\buildTransitive\Effector.Build.targets" />
+</Project>

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -21,6 +21,7 @@ namespace Effector;
 public static class EffectorRuntime
 {
     private const string SupportedAvaloniaVersion = "12.0.0";
+    private static readonly TimeSpan DeferredRenderResourceDisposeDelay = TimeSpan.FromMilliseconds(100);
     private static readonly Version? SkiaSharpAssemblyVersion = typeof(SKRuntimeEffect).Assembly.GetName().Version;
     private static readonly bool IsNativeAot = GetIsNativeAot();
     private static readonly bool? DirectRuntimeShadersOverride = ParseOptionalBooleanEnvironmentVariable("EFFECTOR_ENABLE_DIRECT_RUNTIME_SHADERS");
@@ -28,6 +29,7 @@ public static class EffectorRuntime
     private static readonly string? ShaderSnapshotDir = Environment.GetEnvironmentVariable("EFFECTOR_SHADER_SNAPSHOT_DIR");
 
     private static readonly object Sync = new();
+    private static readonly object DeferredRenderResourceSync = new();
     private static readonly Dictionary<Type, EffectorEffectDescriptor> Descriptors = new();
     private static readonly Dictionary<string, EffectorEffectDescriptor> DescriptorsByName = new(StringComparer.Ordinal);
     private static readonly Dictionary<object, Stack<EffectorShaderEffectFrame>> ShaderFrames = new();
@@ -42,6 +44,7 @@ public static class EffectorRuntime
     private static readonly Dictionary<Type, Queue<Rect>> RenderThreadEffectBoundsByType = new();
     private static readonly Dictionary<Type, Queue<object>> RenderThreadProxiesByType = new();
     private static readonly Dictionary<Type, Queue<object>> RenderThreadVisualsByType = new();
+    private static readonly Queue<DeferredRenderResourceEntry> DeferredRenderResources = new();
     [ThreadStatic] private static bool s_suppressShaderEffectsForVisualSnapshot;
     private static bool s_initialized;
     private static bool s_skiaPatched;
@@ -71,6 +74,37 @@ public static class EffectorRuntime
         }
 
         public Rect Bounds { get; set; }
+    }
+
+    private sealed class DeferredRenderResourceEntry
+    {
+        public DeferredRenderResourceEntry(IDisposable disposable, DateTime dueAtUtc)
+        {
+            Disposable = disposable;
+            DueAtUtc = dueAtUtc;
+        }
+
+        public IDisposable Disposable { get; }
+
+        public DateTime DueAtUtc { get; }
+    }
+
+    private sealed class DeferredRenderResourceBundle : IDisposable
+    {
+        private readonly IDisposable[] _resources;
+
+        public DeferredRenderResourceBundle(params IDisposable?[] resources)
+        {
+            _resources = resources.Where(static resource => resource is not null).Cast<IDisposable>().ToArray();
+        }
+
+        public void Dispose()
+        {
+            for (var index = 0; index < _resources.Length; index++)
+            {
+                _resources[index].Dispose();
+            }
+        }
     }
 
     private sealed class HostVisualHolder
@@ -174,6 +208,11 @@ public static class EffectorRuntime
 
             s_initialized = true;
         }
+    }
+
+    static EffectorRuntime()
+    {
+        AppDomain.CurrentDomain.ProcessExit += static (_, _) => DrainDeferredRenderResources(force: true);
     }
 
     // Effector depends on SkiaSharp 3.x+, so direct runtime shaders should be
@@ -1553,6 +1592,8 @@ public static class EffectorRuntime
 
     private static bool TryBeginShaderEffect(object drawingContext, Rect? effectClipRect, IEffect effect)
     {
+        DrainDeferredRenderResources(force: false);
+
         if (!TryGetDescriptor(effect.GetType(), out var descriptor) || descriptor?.CreateShaderEffect is null)
         {
             TraceShaderPhase(effect, "begin:not-shader");
@@ -1731,92 +1772,117 @@ public static class EffectorRuntime
             TraceShaderPhase(frame.Effect, "end:flush-surface");
             frame.Surface.Flush();
             TraceShaderPhase(frame.Effect, "end:snapshot");
-            using var snapshot = CreateShaderCaptureSnapshot(frame);
+            var snapshot = CreateShaderCaptureSnapshot(frame);
+            SkiaShaderEffect? shaderEffect = null;
+            var deferRenderResourceDispose = false;
             if (snapshot is null)
             {
                 TraceShaderPhase(frame.Effect, "end:snapshot-null");
                 return false;
             }
-            TraceShaderPhase(frame.Effect, "end:snapshot-ok");
-            SaveShaderSnapshot(frame.Effect, snapshot);
-            var contentBounds = ResolveRenderedContentBounds(snapshot, frame.LocalEffectBounds);
-            var globalContentBounds = contentBounds.IsEmpty
-                ? frame.DeviceEffectBounds
-                : OffsetRect(contentBounds, frame.IntermediateSurfaceBounds.Left, frame.IntermediateSurfaceBounds.Top);
-            TraceShaderFrame(
-                frame.Effect,
-                frame.EffectBounds,
-                frame.DeviceEffectBounds,
-                frame.RawEffectRect,
-                frame.DeviceClipBounds,
-                frame.IntermediateSurfaceBounds,
-                contentBounds,
-                globalContentBounds,
-                frame.UsedRenderThreadBounds,
-                frame.TotalMatrix,
-                frame.UsesLocalDrawingCoordinates);
-            if (TryGetDescriptor(frame.Effect.GetType(), out var debugDescriptor) && debugDescriptor is not null)
-            {
-                StoreShaderDebugInfo(
-                    debugDescriptor,
-                    frame.Effect,
-                    new EffectorShaderDebugInfo(
-                        frame.EffectBounds,
-                        frame.DeviceClipBounds,
-                        frame.RawEffectRect,
-                        frame.TotalMatrix,
-                        frame.UsedRenderThreadBounds,
-                        frame.IntermediateSurfaceBounds));
-            }
-            var overlayContentBounds = contentBounds.IsEmpty ? frame.LocalEffectBounds : contentBounds;
-            var normalizedOverlayBounds = NormalizeRectToOrigin(overlayContentBounds);
-            var overlayDestinationBounds = OffsetRect(
-                normalizedOverlayBounds,
-                frame.IntermediateSurfaceBounds.Left + overlayContentBounds.Left,
-                frame.IntermediateSurfaceBounds.Top + overlayContentBounds.Top);
-            var shaderContext = new SkiaShaderEffectContext(
-                frame.EffectContext,
-                snapshot,
-                SKRect.Create(snapshot.Width, snapshot.Height),
-                normalizedOverlayBounds);
-
-            using var shaderEffect = TryCreateShaderEffect(frame.Effect, shaderContext, out var created)
-                ? created
-                : null;
-
-            var restoreCount = frame.PreviousCanvas.Save();
             try
             {
-                TraceShaderPhase(frame.Effect, "end:base-reset");
-                frame.PreviousCanvas.ResetMatrix();
-                frame.PreviousCanvas.ClipRect(frame.DeviceEffectBounds);
-                TraceShaderPhase(frame.Effect, "end:base-draw-image");
-                frame.PreviousCanvas.DrawImage(snapshot, frame.IntermediateSurfaceBounds.Left, frame.IntermediateSurfaceBounds.Top);
-
-                if (shaderEffect is not null)
+                TraceShaderPhase(frame.Effect, "end:snapshot-ok");
+                SaveShaderSnapshot(frame.Effect, snapshot);
+                var contentBounds = ResolveRenderedContentBounds(snapshot, frame.LocalEffectBounds);
+                var globalContentBounds = contentBounds.IsEmpty
+                    ? frame.DeviceEffectBounds
+                    : OffsetRect(contentBounds, frame.IntermediateSurfaceBounds.Left, frame.IntermediateSurfaceBounds.Top);
+                TraceShaderFrame(
+                    frame.Effect,
+                    frame.EffectBounds,
+                    frame.DeviceEffectBounds,
+                    frame.RawEffectRect,
+                    frame.DeviceClipBounds,
+                    frame.IntermediateSurfaceBounds,
+                    contentBounds,
+                    globalContentBounds,
+                    frame.UsedRenderThreadBounds,
+                    frame.TotalMatrix,
+                    frame.UsesLocalDrawingCoordinates);
+                if (TryGetDescriptor(frame.Effect.GetType(), out var debugDescriptor) && debugDescriptor is not null)
                 {
-                    TraceShaderPhase(frame.Effect, "end:overlay");
-                    DrawMaskedShaderOverlay(
-                        drawingContext,
-                        frame.PreviousCanvas,
-                        snapshot,
-                        shaderEffect,
-                        normalizedOverlayBounds,
-                        normalizedOverlayBounds,
-                        overlayDestinationBounds,
-                        new SKPoint(-overlayContentBounds.Left, -overlayContentBounds.Top));
-                    TraceShaderPhase(frame.Effect, "end:overlay-done");
+                    StoreShaderDebugInfo(
+                        debugDescriptor,
+                        frame.Effect,
+                        new EffectorShaderDebugInfo(
+                            frame.EffectBounds,
+                            frame.DeviceClipBounds,
+                            frame.RawEffectRect,
+                            frame.TotalMatrix,
+                            frame.UsedRenderThreadBounds,
+                            frame.IntermediateSurfaceBounds));
+                }
+                var overlayContentBounds = contentBounds.IsEmpty ? frame.LocalEffectBounds : contentBounds;
+                var normalizedOverlayBounds = NormalizeRectToOrigin(overlayContentBounds);
+                var overlayDestinationBounds = OffsetRect(
+                    normalizedOverlayBounds,
+                    frame.IntermediateSurfaceBounds.Left + overlayContentBounds.Left,
+                    frame.IntermediateSurfaceBounds.Top + overlayContentBounds.Top);
+                var shaderContext = new SkiaShaderEffectContext(
+                    frame.EffectContext,
+                    snapshot,
+                    SKRect.Create(snapshot.Width, snapshot.Height),
+                    normalizedOverlayBounds);
+
+                shaderEffect = TryCreateShaderEffect(frame.Effect, shaderContext, out var created)
+                    ? created
+                    : null;
+
+                var restoreCount = frame.PreviousCanvas.Save();
+                try
+                {
+                    TraceShaderPhase(frame.Effect, "end:base-reset");
+                    frame.PreviousCanvas.ResetMatrix();
+                    frame.PreviousCanvas.ClipRect(frame.DeviceEffectBounds);
+                    TraceShaderPhase(frame.Effect, "end:base-draw-image");
+                    frame.PreviousCanvas.DrawImage(snapshot, frame.IntermediateSurfaceBounds.Left, frame.IntermediateSurfaceBounds.Top);
+
+                    if (shaderEffect is not null)
+                    {
+                        TraceShaderPhase(frame.Effect, "end:overlay");
+                        var usedRuntimeShader = DrawMaskedShaderOverlay(
+                            drawingContext,
+                            frame.PreviousCanvas,
+                            snapshot,
+                            shaderEffect,
+                            normalizedOverlayBounds,
+                            normalizedOverlayBounds,
+                            overlayDestinationBounds,
+                            new SKPoint(-overlayContentBounds.Left, -overlayContentBounds.Top));
+                        if (usedRuntimeShader)
+                        {
+                            TraceShaderPhase(frame.Effect, "end:flush-output-canvas");
+                            frame.PreviousCanvas.Flush();
+                            frame.PreviousSurface?.Flush();
+                        }
+                        TraceShaderPhase(frame.Effect, "end:overlay-done");
+                    }
+
+                    deferRenderResourceDispose = true;
+                }
+                finally
+                {
+                    frame.PreviousCanvas.RestoreToCount(restoreCount);
                 }
             }
             finally
             {
-                frame.PreviousCanvas.RestoreToCount(restoreCount);
+                if (deferRenderResourceDispose)
+                {
+                    ScheduleDeferredRenderResources(new DeferredRenderResourceBundle(shaderEffect, snapshot, frame));
+                }
+                else
+                {
+                    shaderEffect?.Dispose();
+                    snapshot.Dispose();
+                    frame.Dispose();
+                }
             }
-
         }
         finally
         {
-            frame.Dispose();
+            DrainDeferredRenderResources(force: false);
         }
 
         return true;
@@ -2438,6 +2504,43 @@ public static class EffectorRuntime
         return frame.Surface.Snapshot();
     }
 
+    private static void ScheduleDeferredRenderResources(IDisposable disposable)
+    {
+        ArgumentNullException.ThrowIfNull(disposable);
+
+        lock (DeferredRenderResourceSync)
+        {
+            DeferredRenderResources.Enqueue(
+                new DeferredRenderResourceEntry(
+                    disposable,
+                    DateTime.UtcNow + DeferredRenderResourceDisposeDelay));
+        }
+    }
+
+    private static void DrainDeferredRenderResources(bool force)
+    {
+        List<IDisposable>? ready = null;
+
+        lock (DeferredRenderResourceSync)
+        {
+            var now = DateTime.UtcNow;
+            while (DeferredRenderResources.Count > 0 &&
+                   (force || DeferredRenderResources.Peek().DueAtUtc <= now))
+            {
+                ready ??= new List<IDisposable>();
+                ready.Add(DeferredRenderResources.Dequeue().Disposable);
+            }
+        }
+
+        if (ready is not null)
+        {
+            for (var index = 0; index < ready.Count; index++)
+            {
+                ready[index].Dispose();
+            }
+        }
+    }
+
     private static SKCanvas? GetCurrentCanvas(object drawingContext) =>
         s_skiaCanvasBackingField?.GetValue(drawingContext) as SKCanvas;
 
@@ -2545,7 +2648,7 @@ public static class EffectorRuntime
             : SKRect.Empty;
     }
 
-    private static void DrawMaskedShaderOverlay(
+    private static bool DrawMaskedShaderOverlay(
         object drawingContext,
         SKCanvas canvas,
         SKImage snapshot,
@@ -2559,9 +2662,10 @@ public static class EffectorRuntime
         destinationRect = Intersect(destinationRect, contentBounds);
         if (destinationRect.IsEmpty)
         {
-            return;
+            return false;
         }
 
+        var usedRuntimeShader = false;
         var restoreCount = canvas.Save();
         try
         {
@@ -2581,6 +2685,7 @@ public static class EffectorRuntime
                 // scratch surface can hang while scrolling large shader sections.
                 if (CanDrawRuntimeShader(drawingContext) && shaderEffect.Shader is not null)
                 {
+                    usedRuntimeShader = true;
                     using var paint = new SKPaint
                     {
                         Shader = shaderEffect.Shader,
@@ -2606,6 +2711,8 @@ public static class EffectorRuntime
         {
             canvas.RestoreToCount(restoreCount);
         }
+
+        return usedRuntimeShader;
     }
 
     private static SKRect NormalizeRectToOrigin(SKRect rect) =>

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -13,6 +13,7 @@ using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using SkiaSharp;
 
@@ -208,11 +209,6 @@ public static class EffectorRuntime
 
             s_initialized = true;
         }
-    }
-
-    static EffectorRuntime()
-    {
-        AppDomain.CurrentDomain.ProcessExit += static (_, _) => DrainDeferredRenderResources(force: true);
     }
 
     // Effector depends on SkiaSharp 3.x+, so direct runtime shaders should be
@@ -589,6 +585,8 @@ public static class EffectorRuntime
 
     public static bool TryGetActiveShaderCanvas(object drawingContext, out SKCanvas canvas)
     {
+        DrainDeferredRenderResources(force: false);
+
         lock (Sync)
         {
             if (ShaderFrames.TryGetValue(drawingContext, out var stack) && stack.Count > 0)
@@ -604,6 +602,8 @@ public static class EffectorRuntime
 
     public static bool TryGetActiveShaderSurface(object drawingContext, out SKSurface? surface)
     {
+        DrainDeferredRenderResources(force: false);
+
         lock (Sync)
         {
             if (ShaderFrames.TryGetValue(drawingContext, out var stack) && stack.Count > 0)
@@ -1870,7 +1870,9 @@ public static class EffectorRuntime
             {
                 if (deferRenderResourceDispose)
                 {
-                    ScheduleDeferredRenderResources(new DeferredRenderResourceBundle(shaderEffect, snapshot, frame));
+                    ScheduleDeferredRenderResources(
+                        new DeferredRenderResourceBundle(shaderEffect, snapshot, frame),
+                        GetDeferredRenderInvalidationTarget(frame.Effect));
                 }
                 else
                 {
@@ -2504,7 +2506,7 @@ public static class EffectorRuntime
         return frame.Surface.Snapshot();
     }
 
-    private static void ScheduleDeferredRenderResources(IDisposable disposable)
+    private static void ScheduleDeferredRenderResources(IDisposable disposable, Visual? invalidationTarget = null)
     {
         ArgumentNullException.ThrowIfNull(disposable);
 
@@ -2514,6 +2516,21 @@ public static class EffectorRuntime
                 new DeferredRenderResourceEntry(
                     disposable,
                     DateTime.UtcNow + DeferredRenderResourceDisposeDelay));
+        }
+
+        if (invalidationTarget is not null)
+        {
+            Dispatcher.UIThread.Post(
+                () => DispatcherTimer.RunOnce(
+                    () =>
+                    {
+                        if (TopLevel.GetTopLevel(invalidationTarget) is not null)
+                        {
+                            invalidationTarget.InvalidateVisual();
+                        }
+                    },
+                    DeferredRenderResourceDisposeDelay),
+                DispatcherPriority.Background);
         }
     }
 
@@ -2539,6 +2556,19 @@ public static class EffectorRuntime
                 ready[index].Dispose();
             }
         }
+    }
+
+    private static Visual? GetDeferredRenderInvalidationTarget(IEffect effect)
+    {
+        lock (Sync)
+        {
+            if (HostVisuals.TryGetValue(effect, out var holder))
+            {
+                return TopLevel.GetTopLevel(holder.Visual) as Visual ?? holder.Visual;
+            }
+        }
+
+        return null;
     }
 
     private static SKCanvas? GetCurrentCanvas(object drawingContext) =>

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -1778,6 +1778,7 @@ public static class EffectorRuntime
             if (snapshot is null)
             {
                 TraceShaderPhase(frame.Effect, "end:snapshot-null");
+                frame.Dispose();
                 return false;
             }
             try

--- a/src/Effector/SkiaRuntimeShaderBuilder.cs
+++ b/src/Effector/SkiaRuntimeShaderBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Threading;
 using SkiaSharp;
@@ -31,7 +32,9 @@ public static class SkiaRuntimeShaderBuilder
         bool isAntialias = true,
         SKRect? destinationRect = null,
         SKMatrix? localMatrix = null,
-        Action<SKCanvas, SKImage, SKRect>? fallbackRenderer = null)
+        Action<SKCanvas, SKImage, SKRect>? fallbackRenderer = null,
+        Action<SKRuntimeEffectChildren, SkiaShaderEffectContext, ICollection<IDisposable>>? configureOwnedChildren = null,
+        IEnumerable<IDisposable>? ownedResources = null)
         => CreateCore(
             sksl,
             context,
@@ -44,6 +47,8 @@ public static class SkiaRuntimeShaderBuilder
             destinationRect,
             localMatrix,
             fallbackRenderer,
+            configureOwnedChildren,
+            ownedResources,
             EffectorRuntime.DirectRuntimeShadersEnabled);
 
     internal static SkiaShaderEffect CreateCore(
@@ -58,7 +63,9 @@ public static class SkiaRuntimeShaderBuilder
         SKRect? destinationRect,
         SKMatrix? localMatrix,
         Action<SKCanvas, SKImage, SKRect>? fallbackRenderer,
-        bool directRuntimeShadersEnabled)
+        Action<SKRuntimeEffectChildren, SkiaShaderEffectContext, ICollection<IDisposable>>? configureOwnedChildren = null,
+        IEnumerable<IDisposable>? ownedResources = null,
+        bool directRuntimeShadersEnabled = true)
     {
         if (string.IsNullOrWhiteSpace(sksl))
         {
@@ -67,11 +74,21 @@ public static class SkiaRuntimeShaderBuilder
 
         var resolvedDestinationRect = destinationRect ?? context.EffectBounds;
         var resolvedLocalMatrix = localMatrix ?? SKMatrix.CreateTranslation(-resolvedDestinationRect.Left, -resolvedDestinationRect.Top);
+        var baseOwnedResources = ownedResources is null ? null : new List<IDisposable>(ownedResources);
 
         if (!directRuntimeShadersEnabled && fallbackRenderer is not null)
         {
-            return new SkiaShaderEffect(null, blendMode, isAntialias, resolvedDestinationRect, resolvedLocalMatrix, fallbackRenderer);
+            return new SkiaShaderEffect(
+                null,
+                blendMode,
+                isAntialias,
+                resolvedDestinationRect,
+                resolvedLocalMatrix,
+                fallbackRenderer,
+                baseOwnedResources);
         }
+
+        List<IDisposable>? transientOwnedResources = null;
 
         try
         {
@@ -80,8 +97,15 @@ public static class SkiaRuntimeShaderBuilder
             configureUniforms?.Invoke(uniforms);
 
             var children = new SKRuntimeEffectChildren(effect);
-            using var contentShader = BindContentShader(contentChildName, children, context);
+            transientOwnedResources = new List<IDisposable>();
+            var contentShader = BindContentShader(contentChildName, children, context);
+            if (contentShader is not null)
+            {
+                transientOwnedResources.Add(contentShader);
+            }
+
             configureChildren?.Invoke(children, context);
+            configureOwnedChildren?.Invoke(children, context, transientOwnedResources);
 
             var shader = effect.ToShader(uniforms, children, resolvedLocalMatrix);
 
@@ -90,11 +114,32 @@ public static class SkiaRuntimeShaderBuilder
                 throw new InvalidOperationException("Runtime shader compilation succeeded, but the shader could not be materialized.");
             }
 
-            return new SkiaShaderEffect(shader, blendMode, isAntialias, resolvedDestinationRect, resolvedLocalMatrix, fallbackRenderer);
+            return new SkiaShaderEffect(
+                shader,
+                blendMode,
+                isAntialias,
+                resolvedDestinationRect,
+                resolvedLocalMatrix,
+                fallbackRenderer,
+                CombineOwnedResources(baseOwnedResources, transientOwnedResources));
         }
         catch when (fallbackRenderer is not null)
         {
-            return new SkiaShaderEffect(null, blendMode, isAntialias, resolvedDestinationRect, resolvedLocalMatrix, fallbackRenderer);
+            DisposeOwnedResources(transientOwnedResources);
+            return new SkiaShaderEffect(
+                null,
+                blendMode,
+                isAntialias,
+                resolvedDestinationRect,
+                resolvedLocalMatrix,
+                fallbackRenderer,
+                baseOwnedResources);
+        }
+        catch
+        {
+            DisposeOwnedResources(transientOwnedResources);
+            DisposeOwnedResources(baseOwnedResources);
+            throw;
         }
     }
 
@@ -137,5 +182,43 @@ public static class SkiaRuntimeShaderBuilder
         var shader = context.CreateContentShader();
         children.Add(contentChildName, shader);
         return shader;
+    }
+
+    private static IReadOnlyList<IDisposable>? CombineOwnedResources(
+        IReadOnlyCollection<IDisposable>? baseOwnedResources,
+        IReadOnlyCollection<IDisposable>? transientOwnedResources)
+    {
+        var baseCount = baseOwnedResources?.Count ?? 0;
+        var transientCount = transientOwnedResources?.Count ?? 0;
+        if (baseCount == 0 && transientCount == 0)
+        {
+            return null;
+        }
+
+        var combined = new List<IDisposable>(baseCount + transientCount);
+        if (baseOwnedResources is not null)
+        {
+            combined.AddRange(baseOwnedResources);
+        }
+
+        if (transientOwnedResources is not null)
+        {
+            combined.AddRange(transientOwnedResources);
+        }
+
+        return combined;
+    }
+
+    private static void DisposeOwnedResources(IReadOnlyList<IDisposable>? ownedResources)
+    {
+        if (ownedResources is null)
+        {
+            return;
+        }
+
+        for (var index = ownedResources.Count - 1; index >= 0; index--)
+        {
+            ownedResources[index].Dispose();
+        }
     }
 }

--- a/src/Effector/SkiaShaderEffect.cs
+++ b/src/Effector/SkiaShaderEffect.cs
@@ -1,17 +1,21 @@
 using System;
+using System.Collections.Generic;
 using SkiaSharp;
 
 namespace Effector;
 
 public sealed class SkiaShaderEffect : IDisposable
 {
+    private readonly IDisposable[] _ownedResources;
+
     public SkiaShaderEffect(
         SKShader? shader,
         SKBlendMode blendMode = SKBlendMode.SrcOver,
         bool isAntialias = true,
         SKRect? destinationRect = null,
         SKMatrix? localMatrix = null,
-        Action<SKCanvas, SKImage, SKRect>? fallbackRenderer = null)
+        Action<SKCanvas, SKImage, SKRect>? fallbackRenderer = null,
+        IEnumerable<IDisposable>? ownedResources = null)
     {
         if (shader is null && fallbackRenderer is null)
         {
@@ -24,6 +28,9 @@ public sealed class SkiaShaderEffect : IDisposable
         DestinationRect = destinationRect;
         LocalMatrix = localMatrix;
         FallbackRenderer = fallbackRenderer;
+        _ownedResources = ownedResources is null
+            ? Array.Empty<IDisposable>()
+            : new List<IDisposable>(ownedResources).ToArray();
     }
 
     public SKShader? Shader { get; }
@@ -56,5 +63,10 @@ public sealed class SkiaShaderEffect : IDisposable
     public void Dispose()
     {
         Shader?.Dispose();
+
+        for (var index = _ownedResources.Length - 1; index >= 0; index--)
+        {
+            _ownedResources[index].Dispose();
+        }
     }
 }

--- a/src/Effector/SkiaShaderImageHandle.cs
+++ b/src/Effector/SkiaShaderImageHandle.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Globalization;
+
+namespace Effector;
+
+public readonly struct SkiaShaderImageHandle : IEquatable<SkiaShaderImageHandle>
+{
+    public SkiaShaderImageHandle(long value)
+    {
+        Value = value;
+    }
+
+    public long Value { get; }
+
+    public bool IsEmpty => Value == 0;
+
+    public bool Equals(SkiaShaderImageHandle other) => Value == other.Value;
+
+    public override bool Equals(object? obj) => obj is SkiaShaderImageHandle other && Equals(other);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public override string ToString() =>
+        IsEmpty
+            ? "empty"
+            : Value.ToString(CultureInfo.InvariantCulture);
+
+    public static bool operator ==(SkiaShaderImageHandle left, SkiaShaderImageHandle right) => left.Equals(right);
+
+    public static bool operator !=(SkiaShaderImageHandle left, SkiaShaderImageHandle right) => !left.Equals(right);
+}

--- a/src/Effector/SkiaShaderImageLease.cs
+++ b/src/Effector/SkiaShaderImageLease.cs
@@ -1,0 +1,30 @@
+using System;
+using SkiaSharp;
+
+namespace Effector;
+
+public sealed class SkiaShaderImageLease : IDisposable
+{
+    private readonly long _handleId;
+    private bool _isDisposed;
+
+    internal SkiaShaderImageLease(long handleId, SKImage image)
+    {
+        _handleId = handleId;
+        Image = image ?? throw new ArgumentNullException(nameof(image));
+    }
+
+    public SKImage Image { get; }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _isDisposed = true;
+        SkiaShaderImageRegistry.ReleaseLease(_handleId);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Effector/SkiaShaderImageRegistry.cs
+++ b/src/Effector/SkiaShaderImageRegistry.cs
@@ -92,18 +92,6 @@ public static class SkiaShaderImageRegistry
         return new SkiaShaderImageHandle(id);
     }
 
-    public static bool TryGetImage(SkiaShaderImageHandle handle, out SKImage? image)
-    {
-        if (handle.IsEmpty || !Images.TryGetValue(handle.Value, out var entry) || entry.IsReleased)
-        {
-            image = null;
-            return false;
-        }
-
-        image = entry.Image;
-        return true;
-    }
-
     public static bool TryAcquire(SkiaShaderImageHandle handle, out SkiaShaderImageLease? lease)
     {
         lease = null;

--- a/src/Effector/SkiaShaderImageRegistry.cs
+++ b/src/Effector/SkiaShaderImageRegistry.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using Avalonia;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using SkiaSharp;
+
+namespace Effector;
+
+public static class SkiaShaderImageRegistry
+{
+    private sealed class ImageEntry : IDisposable
+    {
+        public ImageEntry(SKImage image, SKBitmap? bitmap)
+        {
+            Image = image;
+            Bitmap = bitmap;
+        }
+
+        private int _leaseCount;
+        private int _released;
+
+        public SKImage Image { get; }
+
+        private SKBitmap? Bitmap { get; }
+
+        public bool IsReleased => Volatile.Read(ref _released) != 0;
+
+        public bool TryAcquireLease()
+        {
+            if (IsReleased)
+            {
+                return false;
+            }
+
+            Interlocked.Increment(ref _leaseCount);
+            if (!IsReleased)
+            {
+                return true;
+            }
+
+            ReleaseLease();
+            return false;
+        }
+
+        public bool ReleaseHandle()
+        {
+            if (Interlocked.Exchange(ref _released, 1) != 0)
+            {
+                return false;
+            }
+
+            return Volatile.Read(ref _leaseCount) == 0;
+        }
+
+        public bool ReleaseLease()
+        {
+            var remaining = Interlocked.Decrement(ref _leaseCount);
+            return remaining == 0 && IsReleased;
+        }
+
+        public void Dispose()
+        {
+            Image.Dispose();
+            Bitmap?.Dispose();
+        }
+    }
+
+    private static readonly ConcurrentDictionary<long, ImageEntry> Images = new();
+    private static long s_nextHandleId;
+
+    public static SkiaShaderImageHandle Register(Bitmap bitmap)
+    {
+        if (bitmap is null)
+        {
+            throw new ArgumentNullException(nameof(bitmap));
+        }
+
+        var image = CreateImage(bitmap, out var backingBitmap);
+
+        var id = Interlocked.Increment(ref s_nextHandleId);
+        if (!Images.TryAdd(id, new ImageEntry(image, backingBitmap)))
+        {
+            image.Dispose();
+            backingBitmap?.Dispose();
+            throw new InvalidOperationException("The shader image handle could not be registered.");
+        }
+
+        return new SkiaShaderImageHandle(id);
+    }
+
+    public static bool TryGetImage(SkiaShaderImageHandle handle, out SKImage? image)
+    {
+        if (handle.IsEmpty || !Images.TryGetValue(handle.Value, out var entry) || entry.IsReleased)
+        {
+            image = null;
+            return false;
+        }
+
+        image = entry.Image;
+        return true;
+    }
+
+    public static bool TryAcquire(SkiaShaderImageHandle handle, out SkiaShaderImageLease? lease)
+    {
+        lease = null;
+        if (handle.IsEmpty || !Images.TryGetValue(handle.Value, out var entry) || !entry.TryAcquireLease())
+        {
+            return false;
+        }
+
+        lease = new SkiaShaderImageLease(handle.Value, entry.Image);
+        return true;
+    }
+
+    public static void Release(SkiaShaderImageHandle handle)
+    {
+        if (handle.IsEmpty)
+        {
+            return;
+        }
+
+        if (!Images.TryGetValue(handle.Value, out var entry))
+        {
+            return;
+        }
+
+        if (entry.ReleaseHandle() && Images.TryRemove(handle.Value, out entry))
+        {
+            entry.Dispose();
+        }
+    }
+
+    internal static void ReleaseLease(long handleId)
+    {
+        if (!Images.TryGetValue(handleId, out var entry))
+        {
+            return;
+        }
+
+        if (entry.ReleaseLease() && Images.TryRemove(handleId, out entry))
+        {
+            entry.Dispose();
+        }
+    }
+
+    private static SKImage CreateImage(Bitmap bitmap, out SKBitmap? backingBitmap)
+    {
+        if (TryCreateDirectImage(bitmap, out var image, out backingBitmap))
+        {
+            return image;
+        }
+
+        backingBitmap = null;
+        return CreateEncodedImage(bitmap);
+    }
+
+    private static bool TryCreateDirectImage(Bitmap bitmap, out SKImage image, out SKBitmap? backingBitmap)
+    {
+        image = null!;
+        backingBitmap = null;
+
+        var pixelSize = bitmap.PixelSize;
+        if (pixelSize.Width <= 0 || pixelSize.Height <= 0)
+        {
+            return false;
+        }
+
+        var colorType = bitmap.Format == PixelFormat.Rgba8888
+            ? SKColorType.Rgba8888
+            : bitmap.Format == PixelFormat.Bgra8888
+                ? SKColorType.Bgra8888
+                : SKColorType.Bgra8888;
+        var alphaType = bitmap.AlphaFormat == AlphaFormat.Opaque
+            ? SKAlphaType.Opaque
+            : bitmap.AlphaFormat == AlphaFormat.Unpremul
+                ? SKAlphaType.Unpremul
+                : SKAlphaType.Premul;
+        var imageInfo = new SKImageInfo(pixelSize.Width, pixelSize.Height, colorType, alphaType);
+        backingBitmap = new SKBitmap(imageInfo);
+        var pixels = backingBitmap.GetPixels();
+        if (pixels == IntPtr.Zero)
+        {
+            backingBitmap.Dispose();
+            backingBitmap = null;
+            return false;
+        }
+
+        try
+        {
+            bitmap.CopyPixels(
+                new PixelRect(0, 0, pixelSize.Width, pixelSize.Height),
+                pixels,
+                imageInfo.BytesSize,
+                backingBitmap.RowBytes);
+        }
+        catch
+        {
+            backingBitmap.Dispose();
+            backingBitmap = null;
+            return false;
+        }
+
+        image = SKImage.FromBitmap(backingBitmap);
+        if (image is not null)
+        {
+            return true;
+        }
+
+        backingBitmap.Dispose();
+        backingBitmap = null;
+        return false;
+    }
+
+    private static SKImage CreateEncodedImage(Bitmap bitmap)
+    {
+        using var stream = new MemoryStream();
+        bitmap.Save(stream);
+        using var data = SKData.CreateCopy(stream.ToArray());
+        var image = SKImage.FromEncodedData(data);
+        if (image is null)
+        {
+            throw new InvalidOperationException("The bitmap could not be converted to an SKImage.");
+        }
+
+        return image;
+    }
+}

--- a/src/Effector/SkiaShaderImageRegistry.cs
+++ b/src/Effector/SkiaShaderImageRegistry.cs
@@ -28,8 +28,9 @@ public static class SkiaShaderImageRegistry
 
         public bool IsReleased => Volatile.Read(ref _released) != 0;
 
-        public bool TryAcquireLease()
+        public bool TryAcquireLease(out bool removeReleasedEntry)
         {
+            removeReleasedEntry = false;
             if (IsReleased)
             {
                 return false;
@@ -41,7 +42,7 @@ public static class SkiaShaderImageRegistry
                 return true;
             }
 
-            ReleaseLease();
+            removeReleasedEntry = ReleaseLease();
             return false;
         }
 
@@ -106,8 +107,14 @@ public static class SkiaShaderImageRegistry
     public static bool TryAcquire(SkiaShaderImageHandle handle, out SkiaShaderImageLease? lease)
     {
         lease = null;
-        if (handle.IsEmpty || !Images.TryGetValue(handle.Value, out var entry) || !entry.TryAcquireLease())
+        if (handle.IsEmpty || !Images.TryGetValue(handle.Value, out var entry))
         {
+            return false;
+        }
+
+        if (!entry.TryAcquireLease(out var removeReleasedEntry))
+        {
+            DisposeReleasedEntry(handle.Value, removeReleasedEntry);
             return false;
         }
 
@@ -127,10 +134,7 @@ public static class SkiaShaderImageRegistry
             return;
         }
 
-        if (entry.ReleaseHandle() && Images.TryRemove(handle.Value, out entry))
-        {
-            entry.Dispose();
-        }
+        DisposeReleasedEntry(handle.Value, entry.ReleaseHandle());
     }
 
     internal static void ReleaseLease(long handleId)
@@ -140,7 +144,17 @@ public static class SkiaShaderImageRegistry
             return;
         }
 
-        if (entry.ReleaseLease() && Images.TryRemove(handleId, out entry))
+        DisposeReleasedEntry(handleId, entry.ReleaseLease());
+    }
+
+    private static void DisposeReleasedEntry(long handleId, bool shouldRemove)
+    {
+        if (!shouldRemove)
+        {
+            return;
+        }
+
+        if (Images.TryRemove(handleId, out var entry))
         {
             entry.Dispose();
         }

--- a/tests/Effector.Build.Tasks.Tests/EffectorWeaverTests.cs
+++ b/tests/Effector.Build.Tasks.Tests/EffectorWeaverTests.cs
@@ -191,6 +191,80 @@ public sealed class EffectorWeaverTests
     }
 
     [Fact]
+    public void Weaver_Allows_SkiaShaderImageHandle_Properties()
+    {
+        var assemblyPath = BuildTemporaryAssembly(
+            """
+            using Avalonia;
+            using Avalonia.Media;
+            using Effector;
+            using SkiaSharp;
+
+            namespace SampleEffects;
+
+            [SkiaEffect(typeof(SampleEffectFactory))]
+            public sealed class SampleEffect : SkiaEffectBase, IEffect
+            {
+                public static readonly StyledProperty<SkiaShaderImageHandle> FromImageProperty =
+                    AvaloniaProperty.Register<SampleEffect, SkiaShaderImageHandle>(nameof(FromImage));
+
+                public static readonly StyledProperty<SkiaShaderImageHandle> ToImageProperty =
+                    AvaloniaProperty.Register<SampleEffect, SkiaShaderImageHandle>(nameof(ToImage));
+
+                public static readonly StyledProperty<double> ProgressProperty =
+                    AvaloniaProperty.Register<SampleEffect, double>(nameof(Progress), 0d);
+
+                static SampleEffect()
+                {
+                    AffectsRender<SampleEffect>(FromImageProperty, ToImageProperty, ProgressProperty);
+                }
+
+                public SkiaShaderImageHandle FromImage
+                {
+                    get => GetValue(FromImageProperty);
+                    set => SetValue(FromImageProperty, value);
+                }
+
+                public SkiaShaderImageHandle ToImage
+                {
+                    get => GetValue(ToImageProperty);
+                    set => SetValue(ToImageProperty, value);
+                }
+
+                public double Progress
+                {
+                    get => GetValue(ProgressProperty);
+                    set => SetValue(ProgressProperty, value);
+                }
+            }
+
+            public sealed class SampleEffectFactory :
+                ISkiaEffectFactory<SampleEffect>,
+                ISkiaShaderEffectFactory<SampleEffect>,
+                ISkiaEffectValueFactory,
+                ISkiaShaderEffectValueFactory
+            {
+                public Thickness GetPadding(SampleEffect effect) => default;
+
+                public SKImageFilter? CreateFilter(SampleEffect effect, SkiaEffectContext context) => null;
+
+                public Thickness GetPadding(object[] values) => default;
+
+                public SKImageFilter? CreateFilter(object[] values, SkiaEffectContext context) => null;
+
+                public SkiaShaderEffect? CreateShaderEffect(SampleEffect effect, SkiaShaderEffectContext context) => null;
+
+                public SkiaShaderEffect? CreateShaderEffect(object[] values, SkiaShaderEffectContext context) => null;
+            }
+            """);
+
+        var output = RewriteTemporaryAssembly(assemblyPath);
+
+        Assert.Empty(output.Errors);
+        Assert.Equal(1, output.RewrittenEffectCount);
+    }
+
+    [Fact]
     public void AvaloniaBasePatcher_Rewrites_Target_Methods_And_Is_Idempotent()
     {
         var sourcePath = GetAvaloniaBasePath();

--- a/tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj
+++ b/tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Effector\Effector.csproj"
                       AdditionalProperties="GeneratePackageOnBuild=false" />
+    <ProjectReference Include="..\..\samples\Effector.Compiz.Sample.App\Effector.Compiz.Sample.App.csproj" />
+    <ProjectReference Include="..\..\samples\Effector.Compiz.Sample.Effects\Effector.Compiz.Sample.Effects.csproj" />
     <ProjectReference Include="..\..\samples\Effector.Sample.App\Effector.Sample.App.csproj" />
     <ProjectReference Include="..\..\samples\Effector.Sample.Effects\Effector.Sample.Effects.csproj" />
     <PackageReference Include="Avalonia" />

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -134,13 +134,10 @@ public sealed class EffectorRuntimeBehaviorTests
             try
             {
                 Assert.False(handle.IsEmpty);
-                Assert.True(SkiaShaderImageRegistry.TryGetImage(handle, out var image));
-                Assert.NotNull(image);
-                Assert.Equal(12, image!.Width);
-                Assert.Equal(8, image.Height);
-
                 Assert.True(SkiaShaderImageRegistry.TryAcquire(handle, out lease));
                 Assert.NotNull(lease);
+                Assert.Equal(12, lease!.Image.Width);
+                Assert.Equal(8, lease.Image.Height);
                 AssertColorClose(GetPixel(lease!.Image, 6, 4), expectedColor, tolerance: 4);
             }
             finally
@@ -149,7 +146,7 @@ public sealed class EffectorRuntimeBehaviorTests
                 SkiaShaderImageRegistry.Release(handle);
             }
 
-            Assert.False(SkiaShaderImageRegistry.TryGetImage(handle, out _));
+            Assert.False(SkiaShaderImageRegistry.TryAcquire(handle, out _));
         });
     }
 
@@ -166,14 +163,13 @@ public sealed class EffectorRuntimeBehaviorTests
 
             SkiaShaderImageRegistry.Release(handle);
 
-            Assert.False(SkiaShaderImageRegistry.TryGetImage(handle, out _));
             Assert.False(SkiaShaderImageRegistry.TryAcquire(handle, out _));
             Assert.Equal(10, lease!.Image.Width);
             Assert.Equal(6, lease.Image.Height);
 
             lease.Dispose();
 
-            Assert.False(SkiaShaderImageRegistry.TryGetImage(handle, out _));
+            Assert.False(SkiaShaderImageRegistry.TryAcquire(handle, out _));
         });
     }
 
@@ -305,6 +301,98 @@ public sealed class EffectorRuntimeBehaviorTests
                 Assert.NotNull(nextHost);
                 Assert.NotNull(overlayHost);
                 Assert.Same(nextPage, currentHost!.Content);
+                Assert.Null(nextHost!.Content);
+                Assert.False(nextHost.IsVisible);
+                Assert.False(overlayHost!.IsVisible);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [Fact]
+    public void TransitionPresenter_Replacing_InFlight_Transition_Completes_PreviousAwaiter()
+    {
+        RunOnUiThread(async () =>
+        {
+            var presenter = new TransitionPresenter();
+            var window = new Window
+            {
+                Width = 960,
+                Height = 640,
+                Content = presenter
+            };
+
+            try
+            {
+                window.Show();
+                window.UpdateLayout();
+
+                var initialPage = new Border
+                {
+                    Width = 920,
+                    Height = 560,
+                    Background = Brushes.DarkSlateBlue,
+                    Child = new TextBlock { Text = "Initial", Foreground = Brushes.White }
+                };
+                var firstPage = new Border
+                {
+                    Width = 920,
+                    Height = 560,
+                    Background = Brushes.OrangeRed,
+                    Child = new TextBlock { Text = "First", Foreground = Brushes.White }
+                };
+                var replacementPage = new Border
+                {
+                    Width = 920,
+                    Height = 560,
+                    Background = Brushes.SeaGreen,
+                    Child = new TextBlock { Text = "Replacement", Foreground = Brushes.White }
+                };
+
+                presenter.SetInitialPage(initialPage);
+                window.UpdateLayout();
+
+                var descriptor = new CompizTransitionDescriptor(
+                    CompizTransitionKind.Dissolve,
+                    "test",
+                    "Test",
+                    TimeSpan.FromSeconds(5),
+                    Colors.White,
+                    "test");
+
+                var firstTask = presenter.TransitionToAsync(firstPage, descriptor, new Point(480, 320));
+
+                for (var attempt = 0; attempt < 20 && !ReadField<bool>(presenter, "_isTransitioning"); attempt++)
+                {
+                    await Dispatcher.UIThread.InvokeAsync(
+                        () =>
+                        {
+                            window.UpdateLayout();
+                            presenter.UpdateLayout();
+                        },
+                        DispatcherPriority.Render);
+                    await Task.Delay(10);
+                }
+
+                Assert.True(ReadField<bool>(presenter, "_isTransitioning"));
+
+                await presenter.TransitionToAsync(replacementPage, descriptor, new Point(120, 96));
+
+                var completed = await Task.WhenAny(firstTask, Task.Delay(500));
+                Assert.Same(firstTask, completed);
+                await firstTask;
+
+                var currentHost = presenter.FindControl<ContentControl>("CurrentHost");
+                var nextHost = presenter.FindControl<ContentControl>("NextHost");
+                var overlayHost = presenter.FindControl<Border>("OverlayHost");
+
+                Assert.NotNull(currentHost);
+                Assert.NotNull(nextHost);
+                Assert.NotNull(overlayHost);
+                Assert.Same(replacementPage, currentHost!.Content);
                 Assert.Null(nextHost!.Content);
                 Assert.False(nextHost.IsVisible);
                 Assert.False(overlayHost!.IsVisible);
@@ -3217,6 +3305,13 @@ public sealed class EffectorRuntimeBehaviorTests
         var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         Assert.NotNull(property);
         return (T)property!.GetValue(instance)!;
+    }
+
+    private static T ReadField<T>(object instance, string fieldName)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (T)field!.GetValue(instance)!;
     }
 
     private static Rect GetStoredHostBounds(IEffect effect)

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -13,7 +13,11 @@ using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Effector.Compiz.Sample.App.Controls;
+using Effector.Compiz.Sample.Effects;
 using Effector.Sample.App;
 using Effector.Sample.Effects;
 using SkiaSharp;
@@ -57,6 +61,16 @@ public sealed class EffectorRuntimeBehaviorTests
         }
     }
 
+    private sealed class TrackingDisposable : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+        }
+    }
+
     private sealed class FakeRuntimeShaderDrawingContext
     {
         public object GrContext = new();
@@ -70,6 +84,11 @@ public sealed class EffectorRuntimeBehaviorTests
     private static TResult RunOnUiThread<TResult>(Func<TResult> action)
     {
         return Session.Dispatch(action, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    private static void RunOnUiThread(Func<Task> action)
+    {
+        Session.Dispatch(action, CancellationToken.None).GetAwaiter().GetResult();
     }
 
     [Fact]
@@ -99,6 +118,201 @@ public sealed class EffectorRuntimeBehaviorTests
             Assert.NotNull(immutable);
             Assert.NotSame(effect, immutable);
             Assert.Contains("__EffectorImmutable", immutable.GetType().Name, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ShaderImageRegistry_RoundTrips_BitmapRegistrations()
+    {
+        RunOnUiThread(() =>
+        {
+            var expectedColor = new SKColor(36, 112, 224, 255);
+            using var bitmap = CreateSolidColorBitmap(12, 8, expectedColor);
+            var handle = SkiaShaderImageRegistry.Register(bitmap);
+            SkiaShaderImageLease? lease = null;
+
+            try
+            {
+                Assert.False(handle.IsEmpty);
+                Assert.True(SkiaShaderImageRegistry.TryGetImage(handle, out var image));
+                Assert.NotNull(image);
+                Assert.Equal(12, image!.Width);
+                Assert.Equal(8, image.Height);
+
+                Assert.True(SkiaShaderImageRegistry.TryAcquire(handle, out lease));
+                Assert.NotNull(lease);
+                AssertColorClose(GetPixel(lease!.Image, 6, 4), expectedColor, tolerance: 4);
+            }
+            finally
+            {
+                lease?.Dispose();
+                SkiaShaderImageRegistry.Release(handle);
+            }
+
+            Assert.False(SkiaShaderImageRegistry.TryGetImage(handle, out _));
+        });
+    }
+
+    [Fact]
+    public void ShaderImageRegistry_Leases_KeepImagesAlive_AfterHandleRelease()
+    {
+        RunOnUiThread(() =>
+        {
+            using var bitmap = CreateSolidColorBitmap(10, 6, new SKColor(180, 88, 24, 255));
+            var handle = SkiaShaderImageRegistry.Register(bitmap);
+
+            Assert.True(SkiaShaderImageRegistry.TryAcquire(handle, out var lease));
+            Assert.NotNull(lease);
+
+            SkiaShaderImageRegistry.Release(handle);
+
+            Assert.False(SkiaShaderImageRegistry.TryGetImage(handle, out _));
+            Assert.False(SkiaShaderImageRegistry.TryAcquire(handle, out _));
+            Assert.Equal(10, lease!.Image.Width);
+            Assert.Equal(6, lease.Image.Height);
+
+            lease.Dispose();
+
+            Assert.False(SkiaShaderImageRegistry.TryGetImage(handle, out _));
+        });
+    }
+
+    [Fact]
+    public void CompizCubeTransition_RendersVisibleContent_AtMidProgress()
+    {
+        if (!EffectorRuntime.DirectRuntimeShadersEnabled)
+        {
+            return;
+        }
+
+        RunOnUiThread(() =>
+        {
+            using var fromBitmap = CreateSolidColorBitmap(96, 64, new SKColor(46, 128, 234, 255));
+            using var toBitmap = CreateSolidColorBitmap(96, 64, new SKColor(246, 152, 54, 255));
+            var fromHandle = SkiaShaderImageRegistry.Register(fromBitmap);
+            var toHandle = SkiaShaderImageRegistry.Register(toBitmap);
+
+            try
+            {
+                using var snapshot = CreateOpaqueMaskSnapshot(96, 64);
+                var context = new SkiaShaderEffectContext(
+                    new SkiaEffectContext(1d, usesOpacitySaveLayer: false),
+                    snapshot,
+                    new SKRect(0, 0, 96, 64),
+                    new SKRect(0, 0, 96, 64));
+
+                using var shaderEffect = new CompizTransitionEffectFactory().CreateShaderEffect(
+                    new object[]
+                    {
+                        CompizTransitionKind.Cube,
+                        fromHandle,
+                        toHandle,
+                        0.5d,
+                        0d,
+                        0.75d,
+                        0.5d
+                    },
+                    context);
+
+                Assert.NotNull(shaderEffect);
+                Assert.NotNull(shaderEffect!.Shader);
+
+                using var output = RenderShaderEffectComposite(snapshot, shaderEffect, useRuntimeShader: true);
+                var visibleSamples = 0;
+                for (var y = 8; y < 56; y += 8)
+                {
+                    for (var x = 8; x < 88; x += 8)
+                    {
+                        var pixel = output.GetPixel(x, y);
+                        if (pixel.Alpha > 32 && (pixel.Red > 16 || pixel.Green > 16 || pixel.Blue > 16))
+                        {
+                            visibleSamples++;
+                        }
+                    }
+                }
+
+                Assert.True(
+                    visibleSamples >= 8,
+                    $"Cube transition rendered too few visible samples at mid-progress ({visibleSamples}).");
+            }
+            finally
+            {
+                SkiaShaderImageRegistry.Release(fromHandle);
+                SkiaShaderImageRegistry.Release(toHandle);
+            }
+        });
+    }
+
+    [Fact]
+    public void TransitionPresenter_Promotes_PendingPage_WhenTransitionCompletes()
+    {
+        RunOnUiThread(async () =>
+        {
+            var presenter = new TransitionPresenter();
+            var window = new Window
+            {
+                Width = 960,
+                Height = 640,
+                Content = presenter
+            };
+
+            try
+            {
+                window.Show();
+                window.UpdateLayout();
+
+                var initialPage = new Border
+                {
+                    Width = 920,
+                    Height = 560,
+                    Background = Brushes.DarkSlateBlue,
+                    Child = new TextBlock { Text = "Initial", Foreground = Brushes.White }
+                };
+                var nextPage = new Border
+                {
+                    Width = 920,
+                    Height = 560,
+                    Background = Brushes.OrangeRed,
+                    Child = new TextBlock { Text = "Next", Foreground = Brushes.White }
+                };
+
+                presenter.SetInitialPage(initialPage);
+                window.UpdateLayout();
+
+                await Dispatcher.UIThread.InvokeAsync(
+                    () =>
+                    {
+                        window.UpdateLayout();
+                        presenter.UpdateLayout();
+                    },
+                    DispatcherPriority.Render);
+
+                var descriptor = new CompizTransitionDescriptor(
+                    CompizTransitionKind.Dissolve,
+                    "test",
+                    "Test",
+                    TimeSpan.FromMilliseconds(40),
+                    Colors.White,
+                    "test");
+
+                await presenter.TransitionToAsync(nextPage, descriptor, new Point(480, 320));
+
+                var currentHost = presenter.FindControl<ContentControl>("CurrentHost");
+                var nextHost = presenter.FindControl<ContentControl>("NextHost");
+                var overlayHost = presenter.FindControl<Border>("OverlayHost");
+
+                Assert.NotNull(currentHost);
+                Assert.NotNull(nextHost);
+                Assert.NotNull(overlayHost);
+                Assert.Same(nextPage, currentHost!.Content);
+                Assert.Null(nextHost!.Content);
+                Assert.False(nextHost.IsVisible);
+                Assert.False(overlayHost!.IsVisible);
+            }
+            finally
+            {
+                window.Close();
+            }
         });
     }
 
@@ -1030,6 +1244,39 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public void ShaderBuilder_Disposes_OwnedResources_WithShaderEffect()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(32, 24));
+        Assert.NotNull(surface);
+        using var snapshot = surface!.Snapshot();
+        var context = new SkiaShaderEffectContext(
+            new SkiaEffectContext(1d, usesOpacitySaveLayer: false),
+            snapshot,
+            new SKRect(0, 0, 32, 24),
+            new SKRect(0, 0, 32, 24));
+        var baseOwnedResource = new TrackingDisposable();
+        var childOwnedResource = new TrackingDisposable();
+
+        using (var shaderEffect = SkiaRuntimeShaderBuilder.Create(
+                   "half4 main(float2 coord) { return half4(1.0, 0.0, 0.0, 1.0); }",
+                   context,
+                   configureOwnedChildren: (_, _, ownedResources) =>
+                   {
+                       ownedResources.Add(childOwnedResource);
+                   },
+                   ownedResources: new IDisposable[] { baseOwnedResource }))
+        {
+            Assert.NotNull(shaderEffect);
+            Assert.NotNull(shaderEffect.Shader);
+            Assert.False(baseOwnedResource.IsDisposed);
+            Assert.False(childOwnedResource.IsDisposed);
+        }
+
+        Assert.True(baseOwnedResource.IsDisposed);
+        Assert.True(childOwnedResource.IsDisposed);
+    }
+
+    [Fact]
     public void BurningFlameShaderEffect_RuntimeShaderSource_Compiles_When_Validated()
     {
         var field = typeof(BurningFlameShaderEffectFactory).GetField("ShaderSource", BindingFlags.Static | BindingFlags.NonPublic);
@@ -1041,6 +1288,34 @@ public sealed class EffectorRuntimeBehaviorTests
         using var runtimeEffect = SkiaRuntimeShaderBuilder.CompileShaderSource(shaderSource!);
         Assert.NotNull(runtimeEffect);
         Assert.Contains("content", runtimeEffect.Children);
+    }
+
+    [Fact]
+    public void CompizTransitionShaders_Compile_When_Validated()
+    {
+        var sourceFieldNames = new[]
+        {
+            "DissolveShaderSource",
+            "BurnShaderSource",
+            "CubeShaderSource",
+            "WobblyShaderSource",
+            "GenieShaderSource",
+            "MagneticShaderSource"
+        };
+
+        foreach (var fieldName in sourceFieldNames)
+        {
+            var field = typeof(CompizTransitionEffectFactory).GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+
+            var shaderSource = field!.GetRawConstantValue() as string ?? field.GetValue(null) as string;
+            Assert.False(string.IsNullOrWhiteSpace(shaderSource));
+
+            using var runtimeEffect = SkiaRuntimeShaderBuilder.CompileShaderSource(shaderSource!);
+            Assert.NotNull(runtimeEffect);
+            Assert.Contains("fromImage", runtimeEffect.Children);
+            Assert.Contains("toImage", runtimeEffect.Children);
+        }
     }
 
     [Fact]
@@ -2871,6 +3146,30 @@ public sealed class EffectorRuntimeBehaviorTests
         surface!.Canvas.Clear(SKColors.White);
         surface!.Canvas.Flush();
         return surface.Snapshot();
+    }
+
+    private static Bitmap CreateSolidColorBitmap(int width, int height, SKColor color)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(width, height));
+        Assert.NotNull(surface);
+
+        surface!.Canvas.Clear(color);
+        surface.Canvas.Flush();
+
+        using var data = surface.Snapshot().Encode(SKEncodedImageFormat.Png, 100);
+        Assert.NotNull(data);
+
+        using var stream = new MemoryStream();
+        data!.SaveTo(stream);
+        stream.Position = 0;
+        return new Bitmap(stream);
+    }
+
+    private static SKColor GetPixel(SKImage image, int x, int y)
+    {
+        using var bitmap = new SKBitmap(new SKImageInfo(image.Width, image.Height));
+        Assert.True(image.ReadPixels(bitmap.Info, bitmap.GetPixels(), bitmap.RowBytes, 0, 0));
+        return bitmap.GetPixel(x, y);
     }
 
     private static void AssertColorClose(SKColor actual, SKColor expected, int tolerance)

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -317,6 +317,27 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public void TryGetActiveShaderCanvas_Drains_DueDeferredRenderResources()
+    {
+        ForceDrainDeferredRenderResources();
+
+        var disposable = new TrackingDisposable();
+
+        try
+        {
+            ScheduleDeferredRenderResources(disposable);
+            Thread.Sleep(TimeSpan.FromMilliseconds(250));
+
+            Assert.False(EffectorRuntime.TryGetActiveShaderCanvas(new object(), out _));
+            Assert.True(disposable.IsDisposed);
+        }
+        finally
+        {
+            ForceDrainDeferredRenderResources();
+        }
+    }
+
+    [Fact]
     public void HostBounds_Updates_Propagate_From_Mutable_Effect_To_Frozen_Effect()
     {
         RunOnUiThread(() =>
@@ -1285,7 +1306,8 @@ public sealed class EffectorRuntimeBehaviorTests
         var shaderSource = field!.GetValue(null) as string;
         Assert.False(string.IsNullOrWhiteSpace(shaderSource));
 
-        using var runtimeEffect = SkiaRuntimeShaderBuilder.CompileShaderSource(shaderSource!);
+        // CompileShaderSource returns a cached SKRuntimeEffect instance.
+        var runtimeEffect = SkiaRuntimeShaderBuilder.CompileShaderSource(shaderSource!);
         Assert.NotNull(runtimeEffect);
         Assert.Contains("content", runtimeEffect.Children);
     }
@@ -1311,7 +1333,7 @@ public sealed class EffectorRuntimeBehaviorTests
             var shaderSource = field!.GetRawConstantValue() as string ?? field.GetValue(null) as string;
             Assert.False(string.IsNullOrWhiteSpace(shaderSource));
 
-            using var runtimeEffect = SkiaRuntimeShaderBuilder.CompileShaderSource(shaderSource!);
+            var runtimeEffect = SkiaRuntimeShaderBuilder.CompileShaderSource(shaderSource!);
             Assert.NotNull(runtimeEffect);
             Assert.Contains("fromImage", runtimeEffect.Children);
             Assert.Contains("toImage", runtimeEffect.Children);
@@ -3226,6 +3248,26 @@ public sealed class EffectorRuntimeBehaviorTests
         var maxX = Math.Max(Math.Max(topLeft.Value.X, topRight.Value.X), Math.Max(bottomLeft.Value.X, bottomRight.Value.X));
         var maxY = Math.Max(Math.Max(topLeft.Value.Y, topRight.Value.Y), Math.Max(bottomLeft.Value.Y, bottomRight.Value.Y));
         return new Rect(minX, minY, Math.Max(0d, maxX - minX), Math.Max(0d, maxY - minY));
+    }
+
+    private static void ScheduleDeferredRenderResources(IDisposable disposable)
+    {
+        var method = typeof(EffectorRuntime).GetMethod(
+            "ScheduleDeferredRenderResources",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        method!.Invoke(null, new object?[] { disposable, null });
+    }
+
+    private static void ForceDrainDeferredRenderResources()
+    {
+        var method = typeof(EffectorRuntime).GetMethod(
+            "DrainDeferredRenderResources",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        method!.Invoke(null, new object[] { true });
     }
 
     private static string GetScreenshotPath(string fileName)


### PR DESCRIPTION
# Add Compiz-inspired transition sample and multi-image shader support

## Summary

This PR brings a full Compiz-inspired transition sample to the Effector repository and extends the Skia shader effect pipeline so those transitions can be implemented with Effector's effects API instead of a sample-only workaround.

The result is a new Avalonia desktop sample modeled after `compiz-web`, plus the core runtime and shader lifetime changes required to make dual-image transitions work reliably with SkiaSharp.

## What changed

### Effector core shader infrastructure

- Added `SkiaShaderImageHandle` as a render-safe token for extra shader image inputs.
- Added `SkiaShaderImageLease` so registered shader images can stay alive for the full lifetime of a rendered effect.
- Added `SkiaShaderImageRegistry` to register Avalonia bitmaps, acquire leases, and bridge them into Skia images.
- Extended `SkiaRuntimeShaderBuilder` to accept owned resources and owned child shaders so runtime-created shader graphs keep dependent resources alive until disposal.
- Extended `SkiaShaderEffect` so it can dispose the primary shader together with any extra owned resources.
- Added build-task coverage proving the weaving/runtime path accepts and preserves shader image handle values.

### Runtime integration and hardening

- Integrated the new shader-image path into `EffectorRuntime` for compositor-backed shader rendering.
- Hardened disposal around the runtime shader overlay path by:
  - flushing the destination canvas/surface before teardown,
  - deferring disposal of the compositor-facing render bundle,
  - draining deferred resources back on the render path instead of another thread.
- Optimized shader image registration to use `Bitmap.CopyPixels(...)` with direct pixel upload instead of PNG encode/decode.
- Fixed the direct-upload path to copy into the live `SKBitmap` pixel buffer and to preserve bitmap format/alpha layout correctly.
- Fixed transition completion handoff so the next page is promoted cleanly and the final visual state is always reached.

### New Compiz sample effects package

- Added `samples/Effector.Compiz.Sample.Effects`.
- Implemented a Compiz-inspired transition catalog and effect factory.
- Added SKSL-based transitions plus fallback renderers for:
  - dissolve
  - burn
  - cube
  - wobbly
  - genie
  - magnetic
- Reworked cube behavior toward a ray-cast cube-face rotation model and tightened magnetic behavior to better match the original web app.

### New Avalonia sample application

- Added `samples/Effector.Compiz.Sample.App`.
- Built a routed desktop sample with:
  - page navigation,
  - effect selection,
  - random mode,
  - click-position-aware transitions,
  - persistent effect preferences,
  - multiple content pages inspired by the original demo.
- Added a dedicated `TransitionPresenter` that captures the current/next views, drives progress, manages shader-image handles, and completes transitions cleanly.
- Added an environment-variable-gated stress mode for live transition validation:
  - `EFFECTOR_COMPIZ_AUTOSTRESS`
  - `EFFECTOR_COMPIZ_AUTOSTRESS_EFFECT`
  - `EFFECTOR_COMPIZ_AUTOSTRESS_ITERATIONS`
  - `EFFECTOR_COMPIZ_AUTOSTRESS_FORCE_GC`

### Tests and verification coverage

- Added runtime coverage for:
  - shader image registry round-trips,
  - image lease lifetimes,
  - owned-resource disposal,
  - color preservation for registered images,
  - visible cube output at mid-progress,
  - presenter completion handoff,
  - compile validation for the Compiz shader set.
- Added sample/runtime project wiring needed for the new regression coverage.

### Documentation

- Updated `README.md` with the new secondary shader image capability.
- Added explicit attribution for the Compiz-inspired sample work based on `https://github.com/MaxLeiter/compiz-web`.

## Validation

- Focused runtime and build-task coverage was updated alongside the new infrastructure.
- The compiz sample app was exercised with a live desktop stress run using repeated cube transitions and forced GC/finalizers.
- The final lifetime fix completed an 80-iteration cube stress run successfully with:

```bash
EFFECTOR_COMPIZ_AUTOSTRESS=1 \
EFFECTOR_COMPIZ_AUTOSTRESS_EFFECT=cube \
EFFECTOR_COMPIZ_AUTOSTRESS_ITERATIONS=80 \
EFFECTOR_COMPIZ_AUTOSTRESS_FORCE_GC=1
```

## Commit breakdown

1. `feat(effector): add shader image resource support`
2. `feat(samples): add compiz transition sample app`
3. `fix(runtime): harden compiz transition rendering`
4. `docs: document compiz sample attribution`
