### PR TITLE
fix runtime shader capture lifetimes under repeated invalidation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,8 +30,8 @@
     <PackageOutputPath Condition="'$(PackageOutputPath)' == '' and '$(IsPackable)' == 'true'">$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'artifacts', 'packages'))</PackageOutputPath>
     <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(GITHUB_REF_NAME)' != ''">$(GITHUB_REF_NAME)</RepositoryBranch>
     <RepositoryCommit Condition="'$(RepositoryCommit)' == '' and '$(GITHUB_SHA)' != ''">$(GITHUB_SHA)</RepositoryCommit>
-    <VersionPrefix>0.5.0</VersionPrefix>
-    <EffectorVersion>0.5.0</EffectorVersion>
+    <VersionPrefix>0.6.0</VersionPrefix>
+    <EffectorVersion>0.6.0</EffectorVersion>
     <AvaloniaVersion>12.0.0</AvaloniaVersion>
     <SkiaSharpVersion>3.119.3-preview.1.1</SkiaSharpVersion>
     <RootNamespace Condition="'$(RootNamespace)' == ''">$(MSBuildProjectName)</RootNamespace>

--- a/README.md
+++ b/README.md
@@ -414,18 +414,18 @@ dotnet pack src/Effector/Effector.csproj \
   -p:GeneratePackageOnBuild=false \
   -o artifacts/local-feed
 
-rm -rf ~/.nuget/packages/effector/0.5.0
+rm -rf ~/.nuget/packages/effector/0.6.0
 
 dotnet restore integration/Effector.PackageIntegration.App/Effector.PackageIntegration.App.csproj \
   --configfile integration/NuGet.config \
   --no-cache \
-  -p:EffectorPackageVersion=0.5.0
+  -p:EffectorPackageVersion=0.6.0
 
 dotnet build integration/Effector.PackageIntegration.Tests/Effector.PackageIntegration.Tests.csproj \
   -c Release \
   -m:1 \
   --no-restore \
-  -p:EffectorPackageVersion=0.5.0
+  -p:EffectorPackageVersion=0.6.0
 
 AVALONIA_SCREENSHOT_DIR=$PWD/artifacts/integration-screenshots \
 DYLD_LIBRARY_PATH=$PWD/integration/Effector.PackageIntegration.Tests/bin/Release/net8.0/runtimes/osx/native \
@@ -445,7 +445,7 @@ dotnet publish integration/Effector.PackageIntegration.App/Effector.PackageInteg
   -r osx-arm64 \
   --configfile integration/NuGet.config \
   --no-cache \
-  -p:EffectorPackageVersion=0.5.0 \
+  -p:EffectorPackageVersion=0.6.0 \
   -p:PublishAot=true \
   -p:StripSymbols=false \
   -p:GeneratePackageOnBuild=false

--- a/integration/Directory.Build.props
+++ b/integration/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <EffectorPackageVersion Condition="'$(EffectorPackageVersion)' == ''">0.5.0</EffectorPackageVersion>
+    <EffectorPackageVersion Condition="'$(EffectorPackageVersion)' == ''">0.6.0</EffectorPackageVersion>
   </PropertyGroup>
 </Project>

--- a/plan/avalonia-custom-effects.md
+++ b/plan/avalonia-custom-effects.md
@@ -127,7 +127,7 @@ The produced package includes:
 
 Output package:
 
-- `src/Effector/bin/Debug/Effector.0.5.0.nupkg`
+- `src/Effector/bin/Debug/Effector.0.6.0.nupkg`
 
 ## Sample Deliverables
 

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -1771,18 +1771,25 @@ public static class EffectorRuntime
             frame.Surface.Canvas.Flush();
             TraceShaderPhase(frame.Effect, "end:flush-surface");
             frame.Surface.Flush();
-            TraceShaderPhase(frame.Effect, "end:snapshot");
-            var snapshot = CreateShaderCaptureSnapshot(frame);
+            SKImage? snapshot = null;
             SkiaShaderEffect? shaderEffect = null;
+            IDisposable? deferredLayerOwner = null;
             var deferRenderResourceDispose = false;
-            if (snapshot is null)
-            {
-                TraceShaderPhase(frame.Effect, "end:snapshot-null");
-                frame.Dispose();
-                return false;
-            }
             try
             {
+                TraceShaderPhase(frame.Effect, "end:snapshot");
+                snapshot = CreateShaderCaptureSnapshot(frame);
+                if (snapshot is null)
+                {
+                    TraceShaderPhase(frame.Effect, "end:snapshot-null");
+                    return false;
+                }
+
+                // Once the capture has been materialized as an immutable image, close the
+                // temporary drawing context immediately so animated descendants do not stack
+                // up live capture contexts across subsequent renders.
+                frame.DisposeLayerDrawingContext();
+                TraceShaderPhase(frame.Effect, "end:capture-context-closed");
                 TraceShaderPhase(frame.Effect, "end:snapshot-ok");
                 SaveShaderSnapshot(frame.Effect, snapshot);
                 var contentBounds = ResolveRenderedContentBounds(snapshot, frame.LocalEffectBounds);
@@ -1871,16 +1878,18 @@ public static class EffectorRuntime
             {
                 if (deferRenderResourceDispose)
                 {
+                    deferredLayerOwner = frame.DetachLayerOwner();
                     ScheduleDeferredRenderResources(
-                        new DeferredRenderResourceBundle(shaderEffect, snapshot, frame),
+                        new DeferredRenderResourceBundle(shaderEffect, snapshot, deferredLayerOwner),
                         GetDeferredRenderInvalidationTarget(frame.Effect));
                 }
                 else
                 {
                     shaderEffect?.Dispose();
-                    snapshot.Dispose();
-                    frame.Dispose();
+                    snapshot?.Dispose();
                 }
+
+                frame.Dispose();
             }
         }
         finally

--- a/src/Effector/EffectorShaderEffectFrame.cs
+++ b/src/Effector/EffectorShaderEffectFrame.cs
@@ -7,6 +7,7 @@ namespace Effector;
 internal sealed class EffectorShaderEffectFrame : IDisposable
 {
     private bool _layerDrawingContextDisposed;
+    private IDisposable? _layerOwner;
 
     public EffectorShaderEffectFrame(
         IEffect effect,
@@ -32,7 +33,7 @@ internal sealed class EffectorShaderEffectFrame : IDisposable
         PreviousCanvas = previousCanvas ?? throw new ArgumentNullException(nameof(previousCanvas));
         PreviousSurface = previousSurface;
         Surface = surface ?? throw new ArgumentNullException(nameof(surface));
-        LayerOwner = layerOwner ?? throw new ArgumentNullException(nameof(layerOwner));
+        _layerOwner = layerOwner ?? throw new ArgumentNullException(nameof(layerOwner));
         LayerDrawingContext = layerDrawingContext;
         EffectContext = effectContext;
         DeviceClipBounds = deviceClipBounds;
@@ -56,7 +57,7 @@ internal sealed class EffectorShaderEffectFrame : IDisposable
 
     public SKSurface Surface { get; }
 
-    public IDisposable LayerOwner { get; }
+    public IDisposable? LayerOwner => _layerOwner;
 
     public IDisposable? LayerDrawingContext { get; }
 
@@ -95,9 +96,17 @@ internal sealed class EffectorShaderEffectFrame : IDisposable
         _layerDrawingContextDisposed = true;
     }
 
+    public IDisposable? DetachLayerOwner()
+    {
+        var owner = _layerOwner;
+        _layerOwner = null;
+        return owner;
+    }
+
     public void Dispose()
     {
         DisposeLayerDrawingContext();
-        LayerOwner.Dispose();
+        _layerOwner?.Dispose();
+        _layerOwner = null;
     }
 }

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -426,6 +426,126 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public void ShaderCaptureSnapshot_Remains_Usable_After_SourceSurface_Is_Disposed()
+    {
+        var expectedColor = new SKColor(64, 140, 226, 255);
+        SKImage snapshot;
+
+        using (var surface = SKSurface.Create(new SKImageInfo(12, 8)))
+        {
+            Assert.NotNull(surface);
+            surface!.Canvas.Clear(expectedColor);
+            surface.Canvas.Flush();
+            snapshot = surface.Snapshot();
+        }
+
+        using (snapshot)
+        {
+            AssertColorClose(GetPixel(snapshot, 6, 4), expectedColor, tolerance: 4);
+
+            using var outputSurface = SKSurface.Create(new SKImageInfo(12, 8));
+            Assert.NotNull(outputSurface);
+            outputSurface!.Canvas.Clear(SKColors.Transparent);
+            outputSurface.Canvas.DrawImage(snapshot, 0, 0);
+            outputSurface.Canvas.Flush();
+
+            using var rendered = outputSurface.Snapshot();
+            AssertColorClose(GetPixel(rendered, 6, 4), expectedColor, tolerance: 4);
+        }
+    }
+
+    [Fact]
+    public void ShaderEffectFrame_DisposeLayerDrawingContext_Leaves_LayerOwner_Alive_Until_FrameDispose()
+    {
+        using var previousSurface = SKSurface.Create(new SKImageInfo(8, 8));
+        using var captureSurface = SKSurface.Create(new SKImageInfo(8, 8));
+        Assert.NotNull(previousSurface);
+        Assert.NotNull(captureSurface);
+
+        var layerOwner = new TrackingDisposable();
+        var layerDrawingContext = new TrackingDisposable();
+        var frame = new EffectorShaderEffectFrame(
+            new GridShaderEffect(),
+            previousSurface!.Canvas,
+            previousSurface,
+            captureSurface!,
+            layerOwner,
+            layerDrawingContext,
+            new SkiaEffectContext(1d, usesOpacitySaveLayer: false),
+            new SKRectI(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRectI(0, 0, 8, 8),
+            rawEffectRect: null,
+            previousSurface.Canvas.TotalMatrix,
+            usedRenderThreadBounds: false,
+            usesLocalDrawingCoordinates: true,
+            proxy: null,
+            previousProxyImpl: null);
+
+        try
+        {
+            frame.DisposeLayerDrawingContext();
+            Assert.True(layerDrawingContext.IsDisposed);
+            Assert.False(layerOwner.IsDisposed);
+
+            frame.DisposeLayerDrawingContext();
+            Assert.True(layerDrawingContext.IsDisposed);
+            Assert.False(layerOwner.IsDisposed);
+        }
+        finally
+        {
+            frame.Dispose();
+        }
+
+        Assert.True(layerOwner.IsDisposed);
+    }
+
+    [Fact]
+    public void ShaderEffectFrame_DetachLayerOwner_Defers_OwnerDisposal_Beyond_FrameDispose()
+    {
+        using var previousSurface = SKSurface.Create(new SKImageInfo(8, 8));
+        using var captureSurface = SKSurface.Create(new SKImageInfo(8, 8));
+        Assert.NotNull(previousSurface);
+        Assert.NotNull(captureSurface);
+
+        var layerOwner = new TrackingDisposable();
+        var layerDrawingContext = new TrackingDisposable();
+        var frame = new EffectorShaderEffectFrame(
+            new GridShaderEffect(),
+            previousSurface!.Canvas,
+            previousSurface,
+            captureSurface!,
+            layerOwner,
+            layerDrawingContext,
+            new SkiaEffectContext(1d, usesOpacitySaveLayer: false),
+            new SKRectI(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRectI(0, 0, 8, 8),
+            rawEffectRect: null,
+            previousSurface.Canvas.TotalMatrix,
+            usedRenderThreadBounds: false,
+            usesLocalDrawingCoordinates: true,
+            proxy: null,
+            previousProxyImpl: null);
+
+        var deferredOwner = frame.DetachLayerOwner();
+        Assert.Same(layerOwner, deferredOwner);
+        Assert.Null(frame.LayerOwner);
+
+        frame.Dispose();
+
+        Assert.True(layerDrawingContext.IsDisposed);
+        Assert.False(layerOwner.IsDisposed);
+
+        deferredOwner!.Dispose();
+        Assert.True(layerOwner.IsDisposed);
+    }
+
+    [Fact]
     public void HostBounds_Updates_Propagate_From_Mutable_Effect_To_Frozen_Effect()
     {
         RunOnUiThread(() =>


### PR DESCRIPTION
## Summary

Fixes #15.

This PR fixes the runtime shader capture lifetime bug behind issue #15.

When Effector applied a runtime SkSL shader to a visual and descendant controls kept invalidating during subsequent render passes, the runtime deferred disposal of the entire capture frame for 100 ms. That meant the temporary capture drawing context stayed alive across later renders. On Linux/NVIDIA, that left overlapping live capture contexts in the shader path and could end in a native SIGSEGV after managed rendering had already completed.

## Root Cause

The runtime shader pipeline previously deferred disposal of three different kinds of objects as one bundle:

- the generated shader effect
- the immutable snapshot image used for composition
- the temporary capture frame, including its layer owner and drawing context

The deferred lifetime is reasonable for the compositor-facing shader and snapshot resources, but it was too broad for the temporary capture drawing context. Repeated descendant `InvalidateVisual()` calls could start new render passes while older capture contexts were still open.

There was also a second lifetime constraint to preserve: some layer-backed snapshots can still depend on the layer owner surviving beyond the current method, so the owner should remain deferred even after the capture drawing context is closed.

## What Changed

### Runtime fix

- `EffectorRuntime.TryEndShaderEffect` now materializes the capture snapshot first, then immediately closes the temporary capture drawing context.
- The code now records an explicit `end:capture-context-closed` trace point after early drawing-context disposal.
- Deferred cleanup now keeps only the shader effect, immutable snapshot, and detached layer owner alive.
- The `EffectorShaderEffectFrame` no longer has to keep the layer owner coupled to `Dispose()`. It can now detach the owner so the frame itself can be torn down immediately without invalidating deferred compositor resources.

### Test coverage

Added runtime regression coverage for the new lifetime split:

- snapshot usability after the source surface is disposed
- early `DisposeLayerDrawingContext()` without disposing the owner
- detached owner lifetime surviving `frame.Dispose()`

## User Impact

- Reduces the chance of native crashes when runtime shader effects are active while descendants continue to invalidate and rerender.
- Keeps the safer deferred lifetime for snapshot-backed compositor resources.
- Does not change the public effect authoring API.

## Validation

Executed locally:

- `dotnet test tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj -m:1`
- `dotnet test tests/Effector.Build.Tasks.Tests/Effector.Build.Tasks.Tests.csproj -m:1`

Both passed.

## Notes

- This PR is targeted at issue #15 specifically and is based on the runtime lifetime analysis from the issue thread.
- The repo still emits existing NU1903 restore warnings for `Tmds.DBus.Protocol` during test runs; those warnings are unrelated to this change.
