### PR TITLE
fix(runtime): cap RenderThread*ByType queues to prevent unbounded growth

### DIFF
--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -964,6 +964,7 @@ public static class EffectorRuntime
             }
 
             queue.Enqueue(bounds);
+            while (queue.Count > 2) queue.Dequeue();
         }
     }
 
@@ -980,6 +981,7 @@ public static class EffectorRuntime
             }
 
             queue.Enqueue(proxy);
+            while (queue.Count > 2) queue.Dequeue();
         }
     }
 
@@ -996,6 +998,7 @@ public static class EffectorRuntime
             }
 
             queue.Enqueue(visual);
+            while (queue.Count > 2) queue.Dequeue();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #17.

The three `RenderThread*ByType` fallback queues (`RenderThreadEffectBoundsByType`, `RenderThreadProxiesByType`, `RenderThreadVisualsByType`) grow by one entry per render frame per active shader effect and are never drained, causing a managed memory leak.

This is a separate issue from the capture context lifetime fix in #16 — that PR targets `TryEndShaderEffect`, while this leak is in the `Store*` methods called by `RecordRenderThreadEffect`.

## Root Cause

`RecordRenderThreadEffect` is called by the IL-patched `ServerCompositionPushEffect` on every render frame. The three `Store*` methods write to both:

1. Instance-based `ConditionalWeakTable<IEffect, T>` — bounded (one entry per effect instance)
2. Type-based `Dictionary<Type, Queue<T>>` — **unbounded** (grows by 1 per frame)

The corresponding `Take*` methods check the CWT first and short-circuit on success, so the ByType queues never drain. Additionally:
- `TakeRenderThreadProxy()` has **zero call sites** (dead code)
- `TakeRenderThreadVisual()` is only called from `TryCreateServerVisualSnapshot()`, which is also unreachable

At 60 fps: ~216,000 entries/hour × 3 queues. The `Queue<object>` for proxies/visuals holds strong references to composition-thread objects, preventing GC.

## Fix

Cap each ByType queue to 2 entries after every `Enqueue`:

```csharp
queue.Enqueue(bounds);
while (queue.Count > 2) queue.Dequeue();
```

This preserves the ByType fallback lookup semantics while bounding memory. Applied in all three `Store*` methods.

## Validation

- `dotnet build src/Effector/Effector.csproj -m:1` — 0 errors
- `dotnet test tests/Effector.Runtime.Tests/ -m:1` — 54 passed, 21 skipped, 0 failed
- Reproduced the leak on Android (growing memory) and Linux (eventual instability)
