### PR TITLE
fix: prevent PopEffect from popping parent shader frame for nested filter effects

### DIFF
--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -23,6 +23,7 @@ namespace Effector;
 public static class EffectorRuntime
 {
     private const string SupportedAvaloniaVersion = "12.0.0";
+    private const int DeferredRenderResourceMaxQueueSize = 64;
     private static readonly TimeSpan DeferredRenderResourceDisposeDelay = TimeSpan.FromMilliseconds(100);
     private static readonly Version? SkiaSharpAssemblyVersion = typeof(SKRuntimeEffect).Assembly.GetName().Version;
     private static readonly bool IsNativeAot = GetIsNativeAot();
@@ -827,6 +828,8 @@ public static class EffectorRuntime
         {
             ShaderDebugInfoByType.Clear();
             RenderThreadEffectBoundsByType.Clear();
+            RenderThreadProxiesByType.Clear();
+            RenderThreadVisualsByType.Clear();
         }
     }
 
@@ -984,6 +987,7 @@ public static class EffectorRuntime
             }
 
             queue.Enqueue(bounds);
+            while (queue.Count > 2) queue.Dequeue();
         }
     }
 
@@ -1000,6 +1004,7 @@ public static class EffectorRuntime
             }
 
             queue.Enqueue(proxy);
+            while (queue.Count > 2) queue.Dequeue();
         }
     }
 
@@ -1016,6 +1021,7 @@ public static class EffectorRuntime
             }
 
             queue.Enqueue(visual);
+            while (queue.Count > 2) queue.Dequeue();
         }
     }
 
@@ -2539,12 +2545,22 @@ public static class EffectorRuntime
     {
         ArgumentNullException.ThrowIfNull(disposable);
 
+        bool forceImmediate;
         lock (DeferredRenderResourceSync)
         {
             DeferredRenderResources.Enqueue(
                 new DeferredRenderResourceEntry(
                     disposable,
                     DateTime.UtcNow + DeferredRenderResourceDisposeDelay));
+            forceImmediate = DeferredRenderResources.Count > DeferredRenderResourceMaxQueueSize;
+        }
+
+        // If the queue has grown beyond the safety cap (e.g. DispatcherTimer paused
+        // during Android app-background), drain immediately to bound memory.
+        if (forceImmediate)
+        {
+            DrainDeferredRenderResources(force: true);
+            return;
         }
 
         // Dispose on the UI dispatcher after the grace period instead of invalidating the host

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -37,6 +37,7 @@ public static class EffectorRuntime
     private static readonly Dictionary<Type, EffectorEffectDescriptor> Descriptors = new();
     private static readonly Dictionary<string, EffectorEffectDescriptor> DescriptorsByName = new(StringComparer.Ordinal);
     private static readonly Dictionary<object, Stack<EffectorShaderEffectFrame>> ShaderFrames = new();
+    private static readonly Dictionary<object, Stack<bool>> EffectKindStack = new();
     private static readonly Dictionary<Type, EffectorShaderDebugInfo> ShaderDebugInfoByType = new();
     private static readonly ConditionalWeakTable<object, HostVisualHolder> HostVisuals = new();
     private static readonly ConditionalWeakTable<IEffect, EffectBoundsHolder> HostVisualBounds = new();
@@ -593,7 +594,20 @@ public static class EffectorRuntime
         EnsureInitialized();
         EnsureSkiaMetadata(drawingContext);
         TraceShaderPhase(effect, "begin:patched");
-        return TryBeginShaderEffect(drawingContext, effectClipRect, effect);
+        var isShader = TryBeginShaderEffect(drawingContext, effectClipRect, effect);
+
+        lock (Sync)
+        {
+            if (!EffectKindStack.TryGetValue(drawingContext, out var kindStack))
+            {
+                kindStack = new Stack<bool>();
+                EffectKindStack[drawingContext] = kindStack;
+            }
+
+            kindStack.Push(isShader);
+        }
+
+        return isShader;
     }
 
     public static bool TryEndShaderEffectPatched(object drawingContext)
@@ -601,6 +615,32 @@ public static class EffectorRuntime
         EnsureInitialized();
         EnsureSkiaMetadata(drawingContext);
         TraceShaderGlobalPhase(drawingContext, "end:patched");
+
+        bool wasShader;
+
+        lock (Sync)
+        {
+            if (EffectKindStack.TryGetValue(drawingContext, out var kindStack) && kindStack.Count > 0)
+            {
+                wasShader = kindStack.Pop();
+                if (kindStack.Count == 0)
+                {
+                    EffectKindStack.Remove(drawingContext);
+                }
+            }
+            else
+            {
+                // No tracking entry — fall back to the original behaviour so
+                // standalone shader effects still work correctly.
+                wasShader = true;
+            }
+        }
+
+        if (!wasShader)
+        {
+            return false;
+        }
+
         return TryEndShaderEffect(drawingContext);
     }
 


### PR DESCRIPTION
## Problem

When a **filter effect** (e.g. `SpriteTintEffect` using `SKImageFilter`/`SKColorFilter`) is applied to a child control that sits inside a parent with a **shader effect** (e.g. `SunGlareEffect` using SkSL runtime shaders), `PopEffect` unconditionally pops the top `ShaderFrames` entry — even though the filter effect never pushed onto that stack.

This causes the parent shader to composite prematurely with an incomplete snapshot:
- The child (with the filter) **disappears completely**
- Siblings render on the real canvas **without the shader overlay** (appear darker/unaffected)

Scale, rotation, and opacity transforms work correctly because they don't go through the `ShaderFrames` stack.

## Root cause

`TryEndShaderEffectPatched` always delegates to `TryEndShaderEffect`, which pops the top `ShaderFrames` entry. But filter effects (that return `false` from `TryBeginShaderEffect`) never push onto `ShaderFrames`, creating a push/pop mismatch.

## Fix

Introduces an `EffectKindStack` dictionary (`Dictionary<object, Stack<bool>>`) that tracks whether each `PushEffect` was a shader (`true`) or filter (`false`):

- **`TryBeginShaderEffectPatched`**: after calling `TryBeginShaderEffect`, pushes the result (`isShader`) onto the kind stack
- **`TryEndShaderEffectPatched`**: pops the kind stack — if the effect was a filter, returns `false` early (letting Avalonia handle the `RestoreLayer` normally); only calls `TryEndShaderEffect` for actual shader effects

This also includes the ByType queue cap fix from PR #18.

## Testing

Verified with a real Avalonia app (PokemonBattleEngine) that applies weather shader overlays (`SunGlareEffect`, `HailEffect`, etc.) to a scene while independently applying filter effects (`SpriteTintEffect`, `ScratchGlowEffect`) to child sprites. Before the fix, activating a tint on a sprite under an active weather shader caused the sprite to vanish. After the fix, both effects render correctly and independently.