### PR TITLE
Fix nested filter layers inside shader captures and add sample showcase

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,8 +30,8 @@
     <PackageOutputPath Condition="'$(PackageOutputPath)' == '' and '$(IsPackable)' == 'true'">$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'artifacts', 'packages'))</PackageOutputPath>
     <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(GITHUB_REF_NAME)' != ''">$(GITHUB_REF_NAME)</RepositoryBranch>
     <RepositoryCommit Condition="'$(RepositoryCommit)' == '' and '$(GITHUB_SHA)' != ''">$(GITHUB_SHA)</RepositoryCommit>
-    <VersionPrefix>0.8.0</VersionPrefix>
-    <EffectorVersion>0.8.0</EffectorVersion>
+    <VersionPrefix>0.9.0</VersionPrefix>
+    <EffectorVersion>0.9.0</EffectorVersion>
     <AvaloniaVersion>12.0.0</AvaloniaVersion>
     <SkiaSharpVersion>3.119.3-preview.1.1</SkiaSharpVersion>
     <RootNamespace Condition="'$(RootNamespace)' == ''">$(MSBuildProjectName)</RootNamespace>

--- a/README.md
+++ b/README.md
@@ -414,18 +414,18 @@ dotnet pack src/Effector/Effector.csproj \
   -p:GeneratePackageOnBuild=false \
   -o artifacts/local-feed
 
-rm -rf ~/.nuget/packages/effector/0.8.0
+rm -rf ~/.nuget/packages/effector/0.9.0
 
 dotnet restore integration/Effector.PackageIntegration.App/Effector.PackageIntegration.App.csproj \
   --configfile integration/NuGet.config \
   --no-cache \
-  -p:EffectorPackageVersion=0.8.0
+  -p:EffectorPackageVersion=0.9.0
 
 dotnet build integration/Effector.PackageIntegration.Tests/Effector.PackageIntegration.Tests.csproj \
   -c Release \
   -m:1 \
   --no-restore \
-  -p:EffectorPackageVersion=0.8.0
+  -p:EffectorPackageVersion=0.9.0
 
 AVALONIA_SCREENSHOT_DIR=$PWD/artifacts/integration-screenshots \
 DYLD_LIBRARY_PATH=$PWD/integration/Effector.PackageIntegration.Tests/bin/Release/net8.0/runtimes/osx/native \
@@ -445,7 +445,7 @@ dotnet publish integration/Effector.PackageIntegration.App/Effector.PackageInteg
   -r osx-arm64 \
   --configfile integration/NuGet.config \
   --no-cache \
-  -p:EffectorPackageVersion=0.8.0 \
+  -p:EffectorPackageVersion=0.9.0 \
   -p:PublishAot=true \
   -p:StripSymbols=false \
   -p:GeneratePackageOnBuild=false

--- a/integration/Directory.Build.props
+++ b/integration/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <EffectorPackageVersion Condition="'$(EffectorPackageVersion)' == ''">0.8.0</EffectorPackageVersion>
+    <EffectorPackageVersion Condition="'$(EffectorPackageVersion)' == ''">0.9.0</EffectorPackageVersion>
   </PropertyGroup>
 </Project>

--- a/plan/avalonia-custom-effects.md
+++ b/plan/avalonia-custom-effects.md
@@ -127,7 +127,7 @@ The produced package includes:
 
 Output package:
 
-- `src/Effector/bin/Debug/Effector.0.8.0.nupkg`
+- `src/Effector/bin/Debug/Effector.0.9.0.nupkg`
 
 ## Sample Deliverables
 

--- a/samples/Effector.Sample.App/MainWindow.axaml.cs
+++ b/samples/Effector.Sample.App/MainWindow.axaml.cs
@@ -492,6 +492,7 @@ public partial class MainWindow : Window
         yield return CreateScanlineShaderDefinition();
         yield return CreateGridShaderDefinition();
         yield return CreateSpotlightShaderDefinition();
+        yield return CreateNestedFilterShaderDefinition();
         yield return CreatePointerSpotlightShaderDefinition();
         yield return CreateReactiveGridShaderDefinition();
         yield return CreateWaterRippleShaderDefinition();
@@ -760,6 +761,111 @@ public partial class MainWindow : Window
                     },
                     color => effect.Color = color);
             });
+    }
+
+    private EffectSectionDefinition CreateNestedFilterShaderDefinition()
+    {
+        var effect = new SpotlightShaderEffect
+        {
+            CenterX = 0.78d,
+            CenterY = 0.18d,
+            Radius = 0.52d,
+            Strength = 0.34d,
+            Color = Color.Parse("#FFD26B")
+        };
+
+        var tintColor = Color.Parse("#7FD6FF");
+        var tintStrength = 0.52d;
+        var childTintEffects = new List<TintEffect>();
+
+        TintEffect CreateChildTintEffect()
+        {
+            var childTintEffect = new TintEffect
+            {
+                Color = tintColor,
+                Strength = tintStrength
+            };
+
+            childTintEffects.Add(childTintEffect);
+            return childTintEffect;
+        }
+
+        void UpdateChildTintEffects(Action<TintEffect> apply)
+        {
+            for (var index = 0; index < childTintEffects.Count; index++)
+            {
+                apply(childTintEffects[index]);
+            }
+        }
+
+        return new EffectSectionDefinition(
+            "Nested Filter + Shader",
+            "A child TintEffect stays visible while the parent SpotlightShaderEffect overlays the whole scene. This is the nested filter-under-shader push/pop case that previously broke composition.",
+            effect,
+            """
+            <Border Background="#17232B" Padding="18" CornerRadius="20">
+              <Border.Effect>
+                <effects:SpotlightShaderEffect CenterX="0.78"
+                                              CenterY="0.18"
+                                              Radius="0.52"
+                                              Strength="0.34"
+                                              Color="#FFD26B" />
+              </Border.Effect>
+
+              <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+                <Border Background="#21313A" CornerRadius="18">
+                  <Border.Effect>
+                    <effects:TintEffect Color="#7FD6FF" Strength="0.52" />
+                  </Border.Effect>
+                  <!-- Child with filter -->
+                </Border>
+
+                <Border Grid.Column="1"
+                        Background="#21313A"
+                        CornerRadius="18">
+                  <!-- Sibling without filter -->
+                </Border>
+              </Grid>
+            </Border>
+            """,
+            panel =>
+            {
+                AddSlider(panel, "Glare Strength", 0d, 1d, effect.Strength, v => effect.Strength = v);
+                AddSlider(panel, "Glare Radius", 0.15d, 1d, effect.Radius, v => effect.Radius = v);
+                AddSlider(panel, "Glare X", 0d, 1d, effect.CenterX, v => effect.CenterX = v);
+                AddSlider(panel, "Tint Strength", 0d, 1d, tintStrength, v =>
+                {
+                    tintStrength = v;
+                    UpdateChildTintEffects(childEffect => childEffect.Strength = v);
+                });
+                AddColorSwatches(
+                    panel,
+                    "Glare",
+                    new[]
+                    {
+                        ("Gold", Color.Parse("#FFD26B")),
+                        ("Rose", Color.Parse("#FF9EC8")),
+                        ("Mint", Color.Parse("#9DFFC2")),
+                        ("Ice", Color.Parse("#B9ECFF"))
+                    },
+                    color => effect.Color = color);
+                AddColorSwatches(
+                    panel,
+                    "Child Tint",
+                    new[]
+                    {
+                        ("Cyan", Color.Parse("#7FD6FF")),
+                        ("Coral", Color.Parse("#FF9D7A")),
+                        ("Lime", Color.Parse("#A7F06C")),
+                        ("Violet", Color.Parse("#B596FF"))
+                    },
+                    color =>
+                    {
+                        tintColor = color;
+                        UpdateChildTintEffects(childEffect => childEffect.Color = color);
+                    });
+            },
+            previewEffect => BuildNestedFilterShaderPreview(previewEffect, CreateChildTintEffect));
     }
 
     private EffectSectionDefinition CreatePointerSpotlightShaderDefinition()
@@ -1241,6 +1347,261 @@ public partial class MainWindow : Window
         }.WithRow(2));
 
         return root;
+    }
+
+    private Control BuildNestedFilterShaderPreview(SkiaEffectBase? effect, Func<TintEffect> createChildTintEffect)
+    {
+        var preview = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("1.15*,0.85*"),
+            ColumnSpacing = 14
+        };
+        _previewContentGrids.Add(preview);
+
+        var previewKind = effect is null ? "Before" : "After";
+        var sceneHost = new Border
+        {
+            CornerRadius = new CornerRadius(18),
+            ClipToBounds = true,
+            Tag = "Nested Filter + Shader::" + previewKind + "::Scene",
+            Child = BuildNestedFilterShaderScene(previewKind, createChildTintEffect())
+        };
+
+        if (effect is IEffect avaloniaEffect)
+        {
+            sceneHost.Effect = avaloniaEffect;
+        }
+
+        preview.Children.Add(sceneHost);
+        preview.Children.Add(
+            new StackPanel
+            {
+                Spacing = 12,
+                Children =
+                {
+                    new Border
+                    {
+                        Padding = new Thickness(14),
+                        CornerRadius = new CornerRadius(14),
+                        Background = new SolidColorBrush(Color.Parse("#FFF9FCFF")),
+                        Child = new StackPanel
+                        {
+                            Spacing = 6,
+                            Children =
+                            {
+                                new TextBlock
+                                {
+                                    Text = previewKind == "Before" ? "Filter only" : "Filter + parent shader",
+                                    FontSize = 18,
+                                    FontWeight = FontWeight.SemiBold,
+                                    Foreground = new SolidColorBrush(Color.Parse("#223033"))
+                                },
+                                new TextBlock
+                                {
+                                    Text = previewKind == "Before"
+                                        ? "The left child already runs TintEffect. The right card stays plain so the baseline is easy to compare."
+                                        : "The same child TintEffect stays active while SpotlightShaderEffect overlays the full scene, including the sibling card.",
+                                    TextWrapping = TextWrapping.Wrap,
+                                    Foreground = new SolidColorBrush(Color.Parse("#5D6C72"))
+                                }
+                            }
+                        }
+                    },
+                    new WrapPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        ItemSpacing = 8,
+                        LineSpacing = 8,
+                        Children =
+                        {
+                            CreateChip("child filter"),
+                            CreateChip("parent shader"),
+                            CreateChip("shared scene")
+                        }
+                    },
+                    CreateStatRow("Tinted child", "visible", "#0E9E88"),
+                    CreateStatRow("Sibling overlay", "shared", "#C9781D"),
+                    CreateStatRow("Composition path", "nested", "#2D6CC1")
+                }
+            }.WithColumn(1));
+
+        return preview;
+    }
+
+    private Control BuildNestedFilterShaderScene(string previewKind, TintEffect childTintEffect)
+    {
+        var root = new Border
+        {
+            Padding = new Thickness(18),
+            CornerRadius = new CornerRadius(18),
+            Background = new LinearGradientBrush
+            {
+                StartPoint = new RelativePoint(0d, 0d, RelativeUnit.Relative),
+                EndPoint = new RelativePoint(1d, 1d, RelativeUnit.Relative),
+                GradientStops = new GradientStops
+                {
+                    new GradientStop(Color.Parse("#16232B"), 0d),
+                    new GradientStop(Color.Parse("#233843"), 0.55d),
+                    new GradientStop(Color.Parse("#182129"), 1d)
+                }
+            }
+        };
+
+        var content = new Grid
+        {
+            RowDefinitions = new RowDefinitions("Auto,*,Auto"),
+            RowSpacing = 12
+        };
+
+        content.Children.Add(
+            new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+                Children =
+                {
+                    new StackPanel
+                    {
+                        Spacing = 4,
+                        Children =
+                        {
+                            new TextBlock
+                            {
+                                Text = "Weather overlay composition",
+                                FontSize = 16,
+                                FontWeight = FontWeight.SemiBold,
+                                Foreground = Brushes.White
+                            },
+                            new TextBlock
+                            {
+                                Text = previewKind == "Before"
+                                    ? "Tinted child card without parent shader"
+                                    : "Tinted child card under parent shader glare",
+                                Foreground = new SolidColorBrush(Color.Parse("#B8C6CF")),
+                                TextWrapping = TextWrapping.Wrap
+                            }
+                        }
+                    },
+                    new Border
+                    {
+                        Padding = new Thickness(10, 6),
+                        CornerRadius = new CornerRadius(999),
+                        Background = new SolidColorBrush(Color.Parse("#22FFD26B")),
+                        Child = new TextBlock
+                        {
+                            Text = previewKind,
+                            Foreground = new SolidColorBrush(Color.Parse("#FFE9B0")),
+                            FontWeight = FontWeight.SemiBold
+                        }
+                    }.WithColumn(1)
+                }
+            });
+
+        content.Children.Add(
+            new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("*,*"),
+                ColumnSpacing = 12,
+                Children =
+                {
+                    CreateNestedFilterShaderCard(
+                        "Nested Filter + Shader::" + previewKind + "::TintedChild",
+                        "Tinted child",
+                        "TintEffect stays active",
+                        "#7FD6FF",
+                        childTintEffect),
+                    CreateNestedFilterShaderCard(
+                        "Nested Filter + Shader::" + previewKind + "::SiblingChild",
+                        "Sibling card",
+                        "No child filter, same parent scene",
+                        "#FFD26B",
+                        effect: null).WithColumn(1)
+                }
+            }.WithRow(1));
+
+        content.Children.Add(
+            new WrapPanel
+            {
+                Orientation = Orientation.Horizontal,
+                ItemSpacing = 8,
+                LineSpacing = 8,
+                Children =
+                {
+                    CreateChip("scene root"),
+                    CreateChip("tint child"),
+                    CreateChip("sibling")
+                }
+            }.WithRow(2));
+
+        root.Child = content;
+        return root;
+    }
+
+    private static Border CreateNestedFilterShaderCard(string tag, string title, string subtitle, string accentHex, IEffect? effect)
+    {
+        var accentColor = Color.Parse(accentHex);
+        var card = new Border
+        {
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(18),
+            Background = new SolidColorBrush(Color.Parse("#F7F3EC")),
+            BorderBrush = new SolidColorBrush(Color.Parse("#35FFFFFF")),
+            BorderThickness = new Thickness(1),
+            Tag = tag,
+            Child = new StackPanel
+            {
+                Spacing = 10,
+                Children =
+                {
+                    new Border
+                    {
+                        Width = 42,
+                        Height = 42,
+                        CornerRadius = new CornerRadius(999),
+                        Background = new SolidColorBrush(accentColor),
+                        Child = new TextBlock
+                        {
+                            Text = title.StartsWith("Tinted", StringComparison.Ordinal) ? "T" : "S",
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            FontWeight = FontWeight.Bold,
+                            Foreground = GetRelativeLuminance(accentColor) > 0.55d ? Brushes.Black : Brushes.White
+                        }
+                    },
+                    new TextBlock
+                    {
+                        Text = title,
+                        FontSize = 16,
+                        FontWeight = FontWeight.SemiBold,
+                        Foreground = new SolidColorBrush(Color.Parse("#223033"))
+                    },
+                    new TextBlock
+                    {
+                        Text = subtitle,
+                        TextWrapping = TextWrapping.Wrap,
+                        Foreground = new SolidColorBrush(Color.Parse("#5D6C72"))
+                    },
+                    new Border
+                    {
+                        Padding = new Thickness(10, 8),
+                        CornerRadius = new CornerRadius(12),
+                        Background = new SolidColorBrush(Color.Parse("#FFFFFFFF")),
+                        Child = new TextBlock
+                        {
+                            Text = effect is null ? "Parent shader only" : "Child filter + parent shader",
+                            Foreground = new SolidColorBrush(accentColor),
+                            FontWeight = FontWeight.SemiBold
+                        }
+                    }
+                }
+            }
+        };
+
+        if (effect is not null)
+        {
+            card.Effect = effect;
+        }
+
+        return card;
     }
 
     private static Border CreateChip(string text) =>

--- a/samples/Effector.Sample.App/MainWindow.axaml.cs
+++ b/samples/Effector.Sample.App/MainWindow.axaml.cs
@@ -1536,7 +1536,7 @@ public partial class MainWindow : Window
         return root;
     }
 
-    private static Border CreateNestedFilterShaderCard(string tag, string title, string subtitle, string accentHex, IEffect? effect)
+    private static Border CreateNestedFilterShaderCard(string tag, string title, string subtitle, string accentHex, SkiaEffectBase? effect)
     {
         var accentColor = Color.Parse(accentHex);
         var card = new Border
@@ -1596,9 +1596,9 @@ public partial class MainWindow : Window
             }
         };
 
-        if (effect is not null)
+        if (effect is IEffect avaloniaEffect)
         {
-            card.Effect = effect;
+            card.Effect = avaloniaEffect;
         }
 
         return card;

--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -600,6 +600,12 @@ public static class EffectorRuntime
         EnsureInitialized();
         EnsureSkiaMetadata(drawingContext);
         TraceShaderGlobalPhase(drawingContext, "end:patched");
+
+        if (ShouldRestoreCanvasForActiveShaderFrame(drawingContext))
+        {
+            return false;
+        }
+
         return TryEndShaderEffect(drawingContext);
     }
 
@@ -1576,6 +1582,22 @@ public static class EffectorRuntime
 
         frame = default!;
         return false;
+    }
+
+    private static bool ShouldRestoreCanvasForActiveShaderFrame(object drawingContext)
+    {
+        if (!TryGetActiveShaderFrame(drawingContext, out var frame))
+        {
+            return false;
+        }
+
+        if (frame.Surface.Canvas.SaveCount <= frame.CaptureCanvasSaveCount)
+        {
+            return false;
+        }
+
+        TraceShaderPhase(frame.Effect, "end:restore-layer");
+        return true;
     }
 
     private static SKMatrix ToSKMatrix(Matrix matrix) =>

--- a/src/Effector/EffectorShaderEffectFrame.cs
+++ b/src/Effector/EffectorShaderEffectFrame.cs
@@ -33,6 +33,7 @@ internal sealed class EffectorShaderEffectFrame : IDisposable
         PreviousCanvas = previousCanvas ?? throw new ArgumentNullException(nameof(previousCanvas));
         PreviousSurface = previousSurface;
         Surface = surface ?? throw new ArgumentNullException(nameof(surface));
+        CaptureCanvasSaveCount = Surface.Canvas.SaveCount;
         _layerOwner = layerOwner ?? throw new ArgumentNullException(nameof(layerOwner));
         LayerDrawingContext = layerDrawingContext;
         EffectContext = effectContext;
@@ -56,6 +57,8 @@ internal sealed class EffectorShaderEffectFrame : IDisposable
     public SKSurface? PreviousSurface { get; }
 
     public SKSurface Surface { get; }
+
+    public int CaptureCanvasSaveCount { get; }
 
     public IDisposable? LayerOwner => _layerOwner;
 

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -174,6 +174,49 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public void MainWindow_Contains_NestedFilterShader_Showcase()
+    {
+        RunOnUiThread(() =>
+        {
+            var window = new MainWindow();
+
+            try
+            {
+                window.Show();
+                window.UpdateLayout();
+
+                var section = window.GetVisualDescendants()
+                    .OfType<Border>()
+                    .FirstOrDefault(static border => string.Equals(border.Tag as string, "Nested Filter + Shader::Section", StringComparison.Ordinal));
+                Assert.NotNull(section);
+
+                var afterScene = window.GetVisualDescendants()
+                    .OfType<Border>()
+                    .FirstOrDefault(static border => string.Equals(border.Tag as string, "Nested Filter + Shader::After::Scene", StringComparison.Ordinal));
+                var tintedChild = window.GetVisualDescendants()
+                    .OfType<Border>()
+                    .FirstOrDefault(static border => string.Equals(border.Tag as string, "Nested Filter + Shader::After::TintedChild", StringComparison.Ordinal));
+                var siblingChild = window.GetVisualDescendants()
+                    .OfType<Border>()
+                    .FirstOrDefault(static border => string.Equals(border.Tag as string, "Nested Filter + Shader::After::SiblingChild", StringComparison.Ordinal));
+
+                Assert.NotNull(afterScene);
+                Assert.IsType<SpotlightShaderEffect>(afterScene!.Effect);
+
+                Assert.NotNull(tintedChild);
+                Assert.IsType<TintEffect>(tintedChild!.Effect);
+
+                Assert.NotNull(siblingChild);
+                Assert.Null(siblingChild!.Effect);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [Fact]
     public void CompizCubeTransition_RendersVisibleContent_AtMidProgress()
     {
         if (!EffectorRuntime.DirectRuntimeShadersEnabled)

--- a/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
+++ b/tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs
@@ -561,6 +561,102 @@ public sealed class EffectorRuntimeBehaviorTests
     }
 
     [Fact]
+    public void ActiveShaderFramePopDetection_Does_Not_Defer_When_CaptureCanvas_Is_At_Baseline()
+    {
+        using var previousSurface = SKSurface.Create(new SKImageInfo(8, 8));
+        using var captureSurface = SKSurface.Create(new SKImageInfo(8, 8));
+        Assert.NotNull(previousSurface);
+        Assert.NotNull(captureSurface);
+
+        var frame = new EffectorShaderEffectFrame(
+            new GridShaderEffect(),
+            previousSurface!.Canvas,
+            previousSurface,
+            captureSurface!,
+            new TestDisposable(),
+            layerDrawingContext: null,
+            new SkiaEffectContext(1d, usesOpacitySaveLayer: false),
+            new SKRectI(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRectI(0, 0, 8, 8),
+            rawEffectRect: null,
+            previousSurface.Canvas.TotalMatrix,
+            usedRenderThreadBounds: false,
+            usesLocalDrawingCoordinates: true,
+            proxy: null,
+            previousProxyImpl: null);
+
+        var drawingContext = new object();
+        var shaderFrames = GetShaderFrames();
+        shaderFrames[drawingContext] = new Stack<EffectorShaderEffectFrame>(new[] { frame });
+
+        try
+        {
+            Assert.Equal(captureSurface.Canvas.SaveCount, frame.CaptureCanvasSaveCount);
+            Assert.False(ShouldRestoreCanvasForActiveShaderFrame(drawingContext));
+        }
+        finally
+        {
+            shaderFrames.Remove(drawingContext);
+            frame.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ActiveShaderFramePopDetection_Defers_To_RestoreCanvas_When_Nested_Filter_Layer_Is_Open()
+    {
+        using var previousSurface = SKSurface.Create(new SKImageInfo(8, 8));
+        using var captureSurface = SKSurface.Create(new SKImageInfo(8, 8));
+        Assert.NotNull(previousSurface);
+        Assert.NotNull(captureSurface);
+
+        var frame = new EffectorShaderEffectFrame(
+            new GridShaderEffect(),
+            previousSurface!.Canvas,
+            previousSurface,
+            captureSurface!,
+            new TestDisposable(),
+            layerDrawingContext: null,
+            new SkiaEffectContext(1d, usesOpacitySaveLayer: false),
+            new SKRectI(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRect(0, 0, 8, 8),
+            new SKRectI(0, 0, 8, 8),
+            rawEffectRect: null,
+            previousSurface.Canvas.TotalMatrix,
+            usedRenderThreadBounds: false,
+            usesLocalDrawingCoordinates: true,
+            proxy: null,
+            previousProxyImpl: null);
+
+        var drawingContext = new object();
+        var shaderFrames = GetShaderFrames();
+        shaderFrames[drawingContext] = new Stack<EffectorShaderEffectFrame>(new[] { frame });
+
+        using var paint = new SKPaint();
+
+        try
+        {
+            captureSurface.Canvas.SaveLayer(paint);
+            Assert.True(captureSurface.Canvas.SaveCount > frame.CaptureCanvasSaveCount);
+            Assert.True(ShouldRestoreCanvasForActiveShaderFrame(drawingContext));
+        }
+        finally
+        {
+            if (captureSurface.Canvas.SaveCount > frame.CaptureCanvasSaveCount)
+            {
+                captureSurface.Canvas.Restore();
+            }
+
+            shaderFrames.Remove(drawingContext);
+            frame.Dispose();
+        }
+    }
+
+    [Fact]
     public void HostBounds_Updates_Propagate_From_Mutable_Effect_To_Frozen_Effect()
     {
         RunOnUiThread(() =>
@@ -3447,6 +3543,22 @@ public sealed class EffectorRuntimeBehaviorTests
         var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         Assert.NotNull(field);
         return (T)field!.GetValue(instance)!;
+    }
+
+    private static Dictionary<object, Stack<EffectorShaderEffectFrame>> GetShaderFrames()
+    {
+        var shaderFramesField = typeof(EffectorRuntime).GetField(
+            "ShaderFrames",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        return (Dictionary<object, Stack<EffectorShaderEffectFrame>>)shaderFramesField.GetValue(null)!;
+    }
+
+    private static bool ShouldRestoreCanvasForActiveShaderFrame(object drawingContext)
+    {
+        var method = typeof(EffectorRuntime).GetMethod(
+            "ShouldRestoreCanvasForActiveShaderFrame",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        return (bool)method.Invoke(null, new[] { drawingContext })!;
     }
 
     private static Rect GetStoredHostBounds(IEffect effect)


### PR DESCRIPTION
# PR Summary: Preserve Nested Filter Layers Inside Shader Captures

## Proposed title

Fix nested filter layers under parent shader captures and add sample showcase

## Problem

When a child visual uses a filter-based Effector effect such as `TintEffect`, and an ancestor visual uses a shader-based Effector effect such as `SpotlightShaderEffect`, the patched `PopEffect` path can end the shader capture too early.

In practice, that creates a push/pop ownership mismatch:

- the child filter opens an Avalonia `SaveLayer` on the shader capture canvas
- the patched `PopEffect` assumes the pop belongs to the shader frame itself
- the parent shader frame is composited before the child filter layer is restored

This breaks the nested composition path and can cause:

- filtered children to disappear
- sibling visuals to bypass the parent shader overlay
- partial or prematurely flattened output when filters and runtime shaders are mixed

The branch also adds a concrete sample-app section that demonstrates this exact use case so it remains visible and testable in the gallery.

## Root cause

The hacky direction was to maintain a second bookkeeping structure that records whether each effect push was a shader or a filter. That approach mirrors runtime state instead of deriving it from the real rendering primitive, which makes it easy for the bookkeeping to drift from the actual canvas state.

The real ownership signal already exists on the shader capture canvas itself:

- a shader effect starts a capture frame
- nested filter effects create additional Skia save layers inside that frame
- only the pop that returns the capture canvas to its baseline save depth should end the shader frame

So the correct fix is to make `TryEndShaderEffectPatched` look at capture-canvas save depth, not maintain a parallel effect-kind stack.

## Implementation

### 1. Runtime fix

The runtime now records the shader capture canvas baseline save depth when an `EffectorShaderEffectFrame` is created.

Files:

- `src/Effector/EffectorShaderEffectFrame.cs`
- `src/Effector/EffectorRuntime.cs`

Key change:

- `EffectorShaderEffectFrame` stores `CaptureCanvasSaveCount`
- `TryEndShaderEffectPatched` calls `ShouldRestoreCanvasForActiveShaderFrame`
- if the active shader frame still has nested save layers open, the patched method returns `false`
- returning `false` lets Avalonia run its normal `RestoreCanvas` path on the active capture canvas
- only when the canvas is back at the baseline save depth does the runtime actually end and composite the shader frame

This keeps the ownership model attached to the real canvas state and avoids the previous “queue/stack hack” direction.

### 2. Runtime regression coverage

The runtime tests now explicitly cover the two relevant pop paths.

File:

- `tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs`

Added coverage:

- baseline shader-frame pop does not fall through to `RestoreCanvas`
- nested filter-layer pop does fall through to `RestoreCanvas`

These tests verify the save-depth rule directly and guard the core runtime behavior independently of the sample app.

### 3. Sample-app showcase

The sample gallery now includes a dedicated `Nested Filter + Shader` section.

File:

- `samples/Effector.Sample.App/MainWindow.axaml.cs`

The showcase is designed to demonstrate the fixed scenario clearly:

- the scene contains two sibling cards
- the left card uses a child `TintEffect`
- the right card has no child filter
- the “Before” preview shows the filtered child without the parent shader
- the “After” preview applies a parent `SpotlightShaderEffect` over the whole scene while keeping the child tint intact

It also exposes controls for:

- glare strength
- glare radius
- glare position
- child tint strength
- glare color
- child tint color

This makes the mixed filter/shader composition path visible in the shipped sample instead of only in tests.

### 4. Sample wiring test

A lightweight sample-window test now verifies that the new section exists and that the expected effects are attached to the right nodes.

File:

- `tests/Effector.Runtime.Tests/EffectorRuntimeBehaviorTests.cs`

Verified conditions:

- the sample section is present
- the “After” scene host has a `SpotlightShaderEffect`
- the tinted child keeps a `TintEffect`
- the sibling child remains unfiltered

## Commit breakdown

### Commit 1

`fix(runtime): preserve nested filter layers inside shader captures`

Contains:

- save-depth-based runtime fix
- runtime regression tests for nested filter pops inside shader frames

### Commit 2

`feat(sample): showcase nested filter under parent shader`

Contains:

- new sample gallery section
- sample-window test that verifies the showcase wiring

## Validation

Executed during this branch work:

- `dotnet build samples/Effector.Sample.App/Effector.Sample.App.csproj`
- `dotnet test tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj --filter "MainWindow_Contains_NestedFilterShader_Showcase|ActiveShaderFramePopDetection|ShaderEffectFrame"`
- `dotnet test tests/Effector.Runtime.Tests/Effector.Runtime.Tests.csproj`

Results:

- sample app build passed
- focused regression tests passed
- full runtime test project passed

## Notes for reviewers

- The runtime fix intentionally does **not** add a parallel `EffectKindStack` or similar bookkeeping structure.
- The logic is based on `SKCanvas.SaveCount`, which is the actual primitive that determines whether the current pop belongs to a nested filter layer or the shader capture frame itself.
- The sample section is not just a visual demo; it also gives a straightforward manual verification path for the exact bug class that motivated the fix.

## Suggested reviewer focus

1. Confirm that save-depth ownership is a safer invariant than parallel effect-kind tracking.
2. Check that falling through to Avalonia `RestoreCanvas` is correct when nested filter save layers are still open.
3. Review the sample section for clarity and whether the “Before/After” framing communicates the bug and fix well.
4. Confirm the added tests cover both the runtime invariant and the shipped sample wiring.
