### PR TITLE
fix(runtime): exclude Android from forced raster capture on Linux

### DIFF
--- a/src/Effector/EffectorRuntime.cs
+++ b/src/Effector/EffectorRuntime.cs
@@ -215,7 +215,8 @@ public static class EffectorRuntime
             return envOverride.Value;
         }
 
-        return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            && !OperatingSystem.IsAndroid();
     }
 
     public static void EnsureInitialized()


### PR DESCRIPTION
## Problem

`GetForceRasterCapture()` returns `RuntimeInformation.IsOSPlatform(OSPlatform.Linux)`, which evaluates to `true` on Android (Android IS Linux at the OS level).

This caused forced CPU-backed raster `SKSurface` for all shader effects on Android at 60fps, leading to:
- Native heap growth of ~106 MB in 30 seconds
- GPU upload overhead (raster→GPU copy every frame)
- `ResolveRenderedContentBounds` bitmap copy (~10 MB transient/frame)
- SIGSEGV crash in `libSkiaSharp.so` on the Render Thread within ~65 seconds

## Fix

Add `&& !OperatingSystem.IsAndroid()` guard so the raster capture path is only active on desktop Linux, where the original SIGSEGV fix (#21) was needed.

```csharp
// Before
return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);

// After  
return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
    && !OperatingSystem.IsAndroid();
```

## Result

Android app stable with GPU surfaces as intended. Desktop Linux retains the raster capture fix from #21.