### PR TITLE
Fix browser-wasm Avalonia patch pipeline

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,8 +30,8 @@
     <PackageOutputPath Condition="'$(PackageOutputPath)' == '' and '$(IsPackable)' == 'true'">$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'artifacts', 'packages'))</PackageOutputPath>
     <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(GITHUB_REF_NAME)' != ''">$(GITHUB_REF_NAME)</RepositoryBranch>
     <RepositoryCommit Condition="'$(RepositoryCommit)' == '' and '$(GITHUB_SHA)' != ''">$(GITHUB_SHA)</RepositoryCommit>
-    <VersionPrefix>0.9.1</VersionPrefix>
-    <EffectorVersion>0.9.1</EffectorVersion>
+    <VersionPrefix>0.9.2</VersionPrefix>
+    <EffectorVersion>0.9.2</EffectorVersion>
     <AvaloniaVersion>12.0.0</AvaloniaVersion>
     <SkiaSharpVersion>3.119.3-preview.1.1</SkiaSharpVersion>
     <RootNamespace Condition="'$(RootNamespace)' == ''">$(MSBuildProjectName)</RootNamespace>

--- a/README.md
+++ b/README.md
@@ -414,18 +414,18 @@ dotnet pack src/Effector/Effector.csproj \
   -p:GeneratePackageOnBuild=false \
   -o artifacts/local-feed
 
-rm -rf ~/.nuget/packages/effector/0.9.1
+rm -rf ~/.nuget/packages/effector/0.9.2
 
 dotnet restore integration/Effector.PackageIntegration.App/Effector.PackageIntegration.App.csproj \
   --configfile integration/NuGet.config \
   --no-cache \
-  -p:EffectorPackageVersion=0.9.1
+  -p:EffectorPackageVersion=0.9.2
 
 dotnet build integration/Effector.PackageIntegration.Tests/Effector.PackageIntegration.Tests.csproj \
   -c Release \
   -m:1 \
   --no-restore \
-  -p:EffectorPackageVersion=0.9.1
+  -p:EffectorPackageVersion=0.9.2
 
 AVALONIA_SCREENSHOT_DIR=$PWD/artifacts/integration-screenshots \
 DYLD_LIBRARY_PATH=$PWD/integration/Effector.PackageIntegration.Tests/bin/Release/net8.0/runtimes/osx/native \
@@ -445,7 +445,7 @@ dotnet publish integration/Effector.PackageIntegration.App/Effector.PackageInteg
   -r osx-arm64 \
   --configfile integration/NuGet.config \
   --no-cache \
-  -p:EffectorPackageVersion=0.9.1 \
+  -p:EffectorPackageVersion=0.9.2 \
   -p:PublishAot=true \
   -p:StripSymbols=false \
   -p:GeneratePackageOnBuild=false

--- a/integration/Directory.Build.props
+++ b/integration/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <EffectorPackageVersion Condition="'$(EffectorPackageVersion)' == ''">0.9.1</EffectorPackageVersion>
+    <EffectorPackageVersion Condition="'$(EffectorPackageVersion)' == ''">0.9.2</EffectorPackageVersion>
   </PropertyGroup>
 </Project>

--- a/plan/avalonia-custom-effects.md
+++ b/plan/avalonia-custom-effects.md
@@ -127,7 +127,7 @@ The produced package includes:
 
 Output package:
 
-- `src/Effector/bin/Debug/Effector.0.9.1.nupkg`
+- `src/Effector/bin/Debug/Effector.0.9.2.nupkg`
 
 ## Sample Deliverables
 

--- a/plan/browser-wasm-patching.md
+++ b/plan/browser-wasm-patching.md
@@ -1,0 +1,199 @@
+# Effector Cross-Platform Plan
+
+## Goal
+
+Keep IL weaving as the primary integration path, add a second method that can work on all platforms for issue `#25`, and fix browser-wasm packaging for the current patched lane so issue `#24` is addressed without changing Effector's runtime model.
+
+## Summary
+
+The earlier analysis leads to two tracks:
+
+1. A future cross-platform runtime-only integration path for issue `#25`.
+2. An immediate browser-wasm MSBuild fix for issue `#24`.
+
+These are related, but they solve different problems.
+
+- Issue `#25` is about having a second integration method available on every platform, especially where assembly patching is restricted.
+- Issue `#24` is about the current patch-based integration not flowing into the browser `_framework` bundle.
+
+## Track 1: Alternative Method For Issue `#25`
+
+### Assessment
+
+The current Effector value proposition is not just consumer weaving. It also depends on post-build patching of `Avalonia.Base.dll` and `Avalonia.Skia.dll` so Avalonia calls into `EffectorRuntime` for:
+
+- parsing
+- transitions
+- animator integration
+- immutable conversion
+- render-thread effect bookkeeping
+- shader begin/end and active Skia surface access
+
+That patched lane should remain available because it preserves the transparent `Visual.Effect` experience.
+
+### Recommended Architecture
+
+Do not replace IL weaving. Keep it and add a second integration method beside the patched lane.
+
+Recommended modes:
+
+- `Patched`
+  - current behavior
+  - preserves patched `Visual.Effect`
+- `RuntimeOnly`
+  - keeps consumer weaving
+  - skips Avalonia assembly patching
+  - uses an explicit host/control instead of patched Avalonia internals
+- `Auto`
+  - uses `RuntimeOnly` on unsupported or restricted platforms
+  - uses `Patched` where app-local assembly patching remains viable
+
+### Runtime-Only Direction
+
+The portable path should reuse the existing woven effect metadata and shader factory pipeline, but stop depending on patched Avalonia internals.
+
+Key steps:
+
+1. Keep consumer weaving in both modes so immutable snapshots, registrations, and generated descriptors remain shared.
+2. Extract the portable shader composition logic out of the patched-only render flow in `EffectorRuntime`.
+3. Introduce an explicit runtime host, likely a `Decorator` or `ContentControl`, that:
+   - renders content to a snapshot
+   - submits a custom Skia draw operation
+   - applies Effector shader rendering without patched Avalonia internals
+4. Scope the first runtime-only version to shader effects.
+5. Refactor input tracking so interactive shader effects can attach to the host directly instead of only through `Visual.EffectProperty.Changed`.
+
+### Expected Outcome For Track 1
+
+- IL weaving stays in place.
+- The patched lane remains the richest integration path.
+- A second method becomes available on platforms where patching assemblies is blocked or undesirable.
+- Browser, sandboxed, and assembly-restricted environments get a supported fallback path later.
+
+## Track 2: Browser-WASM Fix For Issue `#24`
+
+### Problem Summary
+
+The browser failure is caused by target timing and input selection, not by the patcher itself.
+
+- Effector currently patches `Avalonia.Base.dll` and `Avalonia.Skia.dll` in `$(TargetDir)` after `CopyFilesToOutputDirectory`.
+- Browser-wasm packaging does not use those late output files as the authoritative source for `_framework`.
+- The WebAssembly/browser SDK resolves the browser payload from copy-local and publish item pipelines before the current Effector patch target becomes relevant.
+
+That means moving the current patch target only slightly earlier or later around `$(TargetDir)` is not enough.
+
+### Implemented Design
+
+The implemented browser-wasm fix keeps the current architecture intact:
+
+- consumer assembly weaving still runs after `CoreCompile`
+- Avalonia patching still remains the integration mechanism for `Visual.Effect`
+- Android and NativeAOT patch lanes remain unchanged
+
+Only the browser-wasm input lane changes.
+
+### Properties
+
+Implemented public switch in `buildTransitive/Effector.Build.props`:
+
+- `EffectorPatchBrowserWasmAssemblies`
+  - default: `true`
+
+Implemented derived browser properties in `buildTransitive/Effector.Build.targets` so they evaluate after project properties like `RuntimeIdentifier` and `IntermediateOutputPath` are known:
+
+- `_EffectorIsBrowserWasm`
+  - true when `$(RuntimeIdentifier) == browser-wasm` or `$(TargetFramework)` ends with `-browser`
+- `_EffectorBrowserPatchedAssemblyDir`
+  - `$(IntermediateOutputPath)\effector-browser-patched`
+
+### Target Changes
+
+The existing late patch targets now skip browser-wasm:
+
+- `Effector_PatchAvaloniaOutputAssemblies`
+- `Effector_PatchAvaloniaPublishAssemblies`
+
+New target:
+
+- `Effector_PatchAvaloniaBrowserReferenceInputs`
+- depends on `Effector_BuildLocalTask`
+- runs after `ResolveReferences`
+- runs before:
+  - `ResolveBuildRelatedStaticWebAssets`
+  - `CopyFilesToOutputDirectory`
+  - `ComputeFilesToPublish`
+  - `StaticWebAssetsPrepareForPublish`
+
+Condition:
+
+- `EffectorEnabled == true`
+- `DesignTimeBuild != true`
+- `_EffectorIsBrowserWasm == true`
+- `EffectorPatchBrowserWasmAssemblies == true`
+
+### Browser-WASM Workflow
+
+For browser-wasm projects:
+
+1. Discover `Avalonia.Base.dll` and `Avalonia.Skia.dll` from `@(ReferenceCopyLocalPaths)`.
+2. Fail fast if either assembly is missing or duplicated.
+3. Copy those assemblies to `$(IntermediateOutputPath)\effector-browser-patched`.
+4. Copy adjacent `.pdb` files when present.
+5. Patch the staged copies with the existing `PatchAvaloniaAssembliesTask`.
+6. Replace the original `@(ReferenceCopyLocalPaths)` items with the staged patched copies.
+7. Preserve browser-relevant metadata, including:
+   - `DestinationSubDirectory`
+   - `DestinationSubPath`
+   - `AssetType`
+   - `Private`
+   - `CopyToPublishDirectory`
+   - `CopyToOutputDirectory`
+   - `NuGetPackageId`
+   - `NuGetPackageVersion`
+   - `ReferenceSourceTarget`
+   - `ResolvedFrom`
+8. Track staged files in `@(FileWrites)` so they can be cleaned.
+
+### Why This Works
+
+The browser SDK builds `_framework` from resolved copy-local and publish item pipelines, not from the late `$(TargetDir)` binaries.
+
+By rewriting `@(ReferenceCopyLocalPaths)` immediately after `ResolveReferences`, the staged patched assemblies become the authoritative inputs for:
+
+- build / run
+- static web assets
+- publish
+- WebCIL generation
+
+## Validation
+
+Implemented build-task coverage in `tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs`:
+
+- browser harness test that stages and patches browser reference inputs
+- assertion that `ReferenceCopyLocalPaths` is rewritten to the staged patched files
+- assertion that `_framework` metadata is preserved
+
+Regression coverage retained:
+
+- existing Android ABI asset patch test still passes
+
+## Follow-Up Work
+
+Recommended next steps after this change:
+
+1. Add a real browser sample smoke test for both WebCIL and non-WebCIL flows.
+2. Decide whether to expose a user-facing integration-mode switch now or only when the runtime-only lane begins.
+3. Start extracting the portable shader rendering path out of the patched Avalonia flow for issue `#25`.
+4. Design the first explicit runtime-only host control around shader effects only.
+
+## Expected Outcome
+
+After the implemented browser-wasm change:
+
+- issue `#24` is addressed in the patch-based lane
+- browser-wasm uses patched Avalonia assemblies before `_framework` packaging
+- WebCIL and non-WebCIL outputs inherit the patched binaries
+
+After the later runtime-only work:
+
+- issue `#25` gets a second supported integration method without removing IL weaving or the existing patched lane

--- a/src/Effector.Build/buildTransitive/Effector.Build.props
+++ b/src/Effector.Build/buildTransitive/Effector.Build.props
@@ -4,5 +4,6 @@
     <EffectorStrict Condition="'$(EffectorStrict)' == ''">true</EffectorStrict>
     <EffectorVerbose Condition="'$(EffectorVerbose)' == ''">false</EffectorVerbose>
     <EffectorSupportedAvaloniaVersion Condition="'$(EffectorSupportedAvaloniaVersion)' == ''">12.0.0</EffectorSupportedAvaloniaVersion>
+    <EffectorPatchBrowserWasmAssemblies Condition="'$(EffectorPatchBrowserWasmAssemblies)' == ''">true</EffectorPatchBrowserWasmAssemblies>
   </PropertyGroup>
 </Project>

--- a/src/Effector.Build/buildTransitive/Effector.Build.targets
+++ b/src/Effector.Build/buildTransitive/Effector.Build.targets
@@ -9,6 +9,8 @@
     <_EffectorTaskAssemblyPath Condition="'$(_EffectorTaskAssemblyPath)' == '' and Exists('$(_EffectorPackagedTaskAssemblyPath)')">$(_EffectorPackagedTaskAssemblyPath)</_EffectorTaskAssemblyPath>
     <_EffectorTaskAssemblyPath Condition="'$(_EffectorTaskAssemblyPath)' == '' and Exists('$(_EffectorLocalTaskProjectPath)')">$(_EffectorLocalTaskAssemblyPath)</_EffectorTaskAssemblyPath>
     <_EffectorAndroidAssetsDir Condition="'$(_EffectorAndroidAssetsDir)' == ''">$([System.IO.Path]::Combine('$(IntermediateOutputPath)', 'android', 'assets'))</_EffectorAndroidAssetsDir>
+    <_EffectorIsBrowserWasm Condition="'$(_EffectorIsBrowserWasm)' == '' and ('$(RuntimeIdentifier)' == 'browser-wasm' or $([System.String]::Copy('$(TargetFramework)').EndsWith('-browser')))">true</_EffectorIsBrowserWasm>
+    <_EffectorBrowserPatchedAssemblyDir Condition="'$(_EffectorBrowserPatchedAssemblyDir)' == ''">$([System.IO.Path]::Combine('$(IntermediateOutputPath)', 'effector-browser-patched'))</_EffectorBrowserPatchedAssemblyDir>
   </PropertyGroup>
 
   <UsingTask TaskName="Effector.Build.Tasks.WeaveSkiaEffectsTask"
@@ -47,10 +49,76 @@
                           SupportedAvaloniaVersion="$(EffectorSupportedAvaloniaVersion)" />
   </Target>
 
+  <Target Name="Effector_PatchAvaloniaBrowserReferenceInputs"
+          AfterTargets="ResolveReferences"
+          BeforeTargets="ResolveBuildRelatedStaticWebAssets;CopyFilesToOutputDirectory;ComputeFilesToPublish;StaticWebAssetsPrepareForPublish"
+          DependsOnTargets="Effector_BuildLocalTask"
+          Condition="'$(EffectorEnabled)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(_EffectorIsBrowserWasm)' == 'true' and '$(EffectorPatchBrowserWasmAssemblies)' == 'true'">
+    <ItemGroup>
+      <_EffectorBrowserAvaloniaReference Include="@(ReferenceCopyLocalPaths)"
+                                         Condition="('%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)' == 'Avalonia.Base.dll' or '%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)' == 'Avalonia.Skia.dll')">
+        <EffectorPatchedPath>$([System.IO.Path]::Combine('$(_EffectorBrowserPatchedAssemblyDir)', '%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)'))</EffectorPatchedPath>
+        <EffectorPdbSourcePath>$([System.IO.Path]::Combine('%(ReferenceCopyLocalPaths.RootDir)%(ReferenceCopyLocalPaths.Directory)', '%(ReferenceCopyLocalPaths.Filename).pdb'))</EffectorPdbSourcePath>
+        <EffectorPatchedPdbPath>$([System.IO.Path]::Combine('$(_EffectorBrowserPatchedAssemblyDir)', '%(ReferenceCopyLocalPaths.Filename).pdb'))</EffectorPatchedPdbPath>
+      </_EffectorBrowserAvaloniaReference>
+      <_EffectorBrowserAvaloniaBase Include="@(_EffectorBrowserAvaloniaReference)"
+                                    Condition="'%(_EffectorBrowserAvaloniaReference.Filename)%(_EffectorBrowserAvaloniaReference.Extension)' == 'Avalonia.Base.dll'" />
+      <_EffectorBrowserAvaloniaSkia Include="@(_EffectorBrowserAvaloniaReference)"
+                                    Condition="'%(_EffectorBrowserAvaloniaReference.Filename)%(_EffectorBrowserAvaloniaReference.Extension)' == 'Avalonia.Skia.dll'" />
+      <_EffectorBrowserAvaloniaReferenceToStage Include="@(_EffectorBrowserAvaloniaReference)"
+                                                Condition="'%(_EffectorBrowserAvaloniaReference.Identity)' != '%(_EffectorBrowserAvaloniaReference.EffectorPatchedPath)'" />
+    </ItemGroup>
+
+    <Error Condition="'@(_EffectorBrowserAvaloniaBase->Count())' != '1'"
+           Text="[Effector.Build] Browser-wasm patching expected exactly one Avalonia.Base.dll in @(ReferenceCopyLocalPaths), but found '@(_EffectorBrowserAvaloniaBase->Count())'." />
+    <Error Condition="'@(_EffectorBrowserAvaloniaSkia->Count())' != '1'"
+           Text="[Effector.Build] Browser-wasm patching expected exactly one Avalonia.Skia.dll in @(ReferenceCopyLocalPaths), but found '@(_EffectorBrowserAvaloniaSkia->Count())'." />
+
+    <Message Importance="High"
+             Text="[Effector.Build] patching browser-wasm Avalonia inputs from '%(_EffectorBrowserAvaloniaBase.Identity)' and '%(_EffectorBrowserAvaloniaSkia.Identity)' into '$(_EffectorBrowserPatchedAssemblyDir)'."
+             Condition="'$(EffectorVerbose)' == 'true'" />
+
+    <MakeDir Directories="$(_EffectorBrowserPatchedAssemblyDir)" />
+
+    <Copy SourceFiles="@(_EffectorBrowserAvaloniaReferenceToStage)"
+          DestinationFiles="@(_EffectorBrowserAvaloniaReferenceToStage->'%(EffectorPatchedPath)')"
+          SkipUnchangedFiles="false"
+          OverwriteReadOnlyFiles="true"
+          Condition="'@(_EffectorBrowserAvaloniaReferenceToStage)' != ''" />
+
+    <ItemGroup>
+      <_EffectorBrowserAvaloniaPdb Include="@(_EffectorBrowserAvaloniaReference)"
+                                   Condition="Exists('%(_EffectorBrowserAvaloniaReference.EffectorPdbSourcePath)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_EffectorBrowserAvaloniaPdb->'%(EffectorPdbSourcePath)')"
+          DestinationFiles="@(_EffectorBrowserAvaloniaPdb->'%(EffectorPatchedPdbPath)')"
+          SkipUnchangedFiles="false"
+          OverwriteReadOnlyFiles="true"
+          Condition="'@(_EffectorBrowserAvaloniaPdb)' != '' and '@(_EffectorBrowserAvaloniaReferenceToStage)' != ''" />
+
+    <PatchAvaloniaAssembliesTask AvaloniaBaseAssemblyPath="%(_EffectorBrowserAvaloniaBase.EffectorPatchedPath)"
+                                 AvaloniaSkiaAssemblyPath="%(_EffectorBrowserAvaloniaSkia.EffectorPatchedPath)"
+                                 Strict="$(EffectorStrict)"
+                                 Verbose="$(EffectorVerbose)"
+                                 SupportedAvaloniaVersion="$(EffectorSupportedAvaloniaVersion)" />
+
+    <ItemGroup>
+      <_EffectorBrowserPatchedReference Include="@(_EffectorBrowserAvaloniaReference->'%(EffectorPatchedPath)')"
+                                        KeepMetadata="DestinationSubDirectory;DestinationSubPath;AssetType;Private;CopyToPublishDirectory;CopyToOutputDirectory;NuGetPackageId;NuGetPackageVersion;NuGetSourceType;PackageName;ReferenceSourceTarget;HintPath;ResolvedFrom;FusionName;PathInPackage;ExternallyResolved;RuntimeIdentifier;Culture;MSBuildSourceProjectFile;MSBuildSourceTargetName;OriginalItemSpec;TargetPath">
+        <EffectorOriginalItemSpec>%(_EffectorBrowserAvaloniaReference.Identity)</EffectorOriginalItemSpec>
+      </_EffectorBrowserPatchedReference>
+      <ReferenceCopyLocalPaths Remove="@(_EffectorBrowserAvaloniaReference)" />
+      <ReferenceCopyLocalPaths Include="@(_EffectorBrowserPatchedReference)" />
+      <FileWrites Include="@(_EffectorBrowserAvaloniaReference->'%(EffectorPatchedPath)')" />
+      <FileWrites Include="@(_EffectorBrowserAvaloniaPdb->'%(EffectorPatchedPdbPath)')" Condition="'@(_EffectorBrowserAvaloniaPdb)' != ''" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="Effector_PatchAvaloniaOutputAssemblies"
           AfterTargets="CopyFilesToOutputDirectory"
           DependsOnTargets="Effector_BuildLocalTask"
-          Condition="'$(EffectorEnabled)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(TargetDir)' != ''">
+          Condition="'$(EffectorEnabled)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(_EffectorIsBrowserWasm)' != 'true' and '$(TargetDir)' != ''">
     <PatchAvaloniaAssembliesTask AvaloniaBaseAssemblyPath="$([System.IO.Path]::Combine('$(TargetDir)', 'Avalonia.Base.dll'))"
                                  AvaloniaSkiaAssemblyPath="$([System.IO.Path]::Combine('$(TargetDir)', 'Avalonia.Skia.dll'))"
                                  Strict="$(EffectorStrict)"
@@ -118,7 +186,7 @@
   <Target Name="Effector_PatchAvaloniaPublishAssemblies"
           AfterTargets="Publish"
           DependsOnTargets="Effector_BuildLocalTask"
-          Condition="'$(EffectorEnabled)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(PublishDir)' != ''">
+          Condition="'$(EffectorEnabled)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(_EffectorIsBrowserWasm)' != 'true' and '$(PublishDir)' != ''">
     <PatchAvaloniaAssembliesTask AvaloniaBaseAssemblyPath="$([System.IO.Path]::Combine('$(PublishDir)', 'Avalonia.Base.dll'))"
                                  AvaloniaSkiaAssemblyPath="$([System.IO.Path]::Combine('$(PublishDir)', 'Avalonia.Skia.dll'))"
                                  Strict="$(EffectorStrict)"

--- a/tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs
+++ b/tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs
@@ -64,6 +64,85 @@ public sealed class EffectorBuildTargetsTests
         }
     }
 
+    [Fact]
+    public void BrowserBuildTarget_Patches_AvaloniaReferenceInputs_And_Rewrites_CopyLocalPaths()
+    {
+        var testRoot = Path.Combine(Path.GetTempPath(), "effector-browser-target-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testRoot);
+
+        var referencesRoot = Path.Combine(testRoot, "references");
+        Directory.CreateDirectory(referencesRoot);
+        CopyAvaloniaAssemblyPair(referencesRoot);
+
+        var initialBasePath = Path.Combine(referencesRoot, "Avalonia.Base.dll");
+        var initialSkiaPath = Path.Combine(referencesRoot, "Avalonia.Skia.dll");
+        var scanner = new AvaloniaPatchMetadataScanner();
+
+        Assert.False(scanner.Scan(initialBasePath, "12.0.0", AvaloniaPatchAssemblyKind.Base).IsAlreadyPatched);
+        Assert.False(scanner.Scan(initialSkiaPath, "12.0.0", AvaloniaPatchAssemblyKind.Skia).IsAlreadyPatched);
+
+        var intermediateOutputPath = Path.Combine(testRoot, "obj", "Debug", "net8.0-browser");
+        var capturePath = Path.Combine(testRoot, "browser-reference-copy-local-paths.txt");
+        var projectPath = Path.Combine(testRoot, "BrowserPatchHarness.csproj");
+        CreateBrowserPatchHarnessProject(projectPath, intermediateOutputPath, initialBasePath, initialSkiaPath, capturePath);
+
+        var result = RunProcess(
+            "dotnet",
+            new[]
+            {
+                "msbuild",
+                projectPath,
+                "-t:Effector_PatchAvaloniaBrowserReferenceInputs;CaptureReferenceCopyLocalPaths",
+                "-m:1",
+                "-v:minimal"
+            },
+            testRoot);
+
+        Assert.True(result.ExitCode == 0, result.Output);
+
+        var stagedDirectory = Path.Combine(intermediateOutputPath, "effector-browser-patched");
+        var stagedBasePath = Path.Combine(stagedDirectory, "Avalonia.Base.dll");
+        var stagedSkiaPath = Path.Combine(stagedDirectory, "Avalonia.Skia.dll");
+
+        Assert.True(File.Exists(stagedBasePath), $"Expected staged Avalonia.Base.dll at '{stagedBasePath}'.{Environment.NewLine}{result.Output}");
+        Assert.True(File.Exists(stagedSkiaPath), $"Expected staged Avalonia.Skia.dll at '{stagedSkiaPath}'.{Environment.NewLine}{result.Output}");
+        Assert.True(scanner.Scan(stagedBasePath, "12.0.0", AvaloniaPatchAssemblyKind.Base).IsAlreadyPatched, result.Output);
+        Assert.True(scanner.Scan(stagedSkiaPath, "12.0.0", AvaloniaPatchAssemblyKind.Skia).IsAlreadyPatched, result.Output);
+        Assert.False(scanner.Scan(initialBasePath, "12.0.0", AvaloniaPatchAssemblyKind.Base).IsAlreadyPatched, result.Output);
+        Assert.False(scanner.Scan(initialSkiaPath, "12.0.0", AvaloniaPatchAssemblyKind.Skia).IsAlreadyPatched, result.Output);
+
+        Assert.True(File.Exists(capturePath), $"Expected capture file at '{capturePath}'.{Environment.NewLine}{result.Output}");
+        var lines = File.ReadAllLines(capturePath);
+
+        Assert.Contains(lines, line => line.StartsWith(stagedBasePath + "|", StringComparison.Ordinal));
+        Assert.Contains(lines, line => line.StartsWith(stagedSkiaPath + "|", StringComparison.Ordinal));
+        Assert.Contains(lines, line => line.Contains("_framework", StringComparison.Ordinal));
+        Assert.Contains(lines, line => line.Contains("runtime", StringComparison.Ordinal));
+        Assert.Contains(lines, line => line.Contains("PreserveNewest", StringComparison.Ordinal));
+
+        var secondResult = RunProcess(
+            "dotnet",
+            new[]
+            {
+                "msbuild",
+                projectPath,
+                "-t:Effector_PatchAvaloniaBrowserReferenceInputs;CaptureReferenceCopyLocalPaths",
+                "-m:1",
+                "-v:minimal"
+            },
+            testRoot);
+
+        Assert.True(secondResult.ExitCode == 0, secondResult.Output);
+        Assert.True(scanner.Scan(stagedBasePath, "12.0.0", AvaloniaPatchAssemblyKind.Base).IsAlreadyPatched, secondResult.Output);
+        Assert.True(scanner.Scan(stagedSkiaPath, "12.0.0", AvaloniaPatchAssemblyKind.Skia).IsAlreadyPatched, secondResult.Output);
+        Assert.False(scanner.Scan(initialBasePath, "12.0.0", AvaloniaPatchAssemblyKind.Base).IsAlreadyPatched, secondResult.Output);
+        Assert.False(scanner.Scan(initialSkiaPath, "12.0.0", AvaloniaPatchAssemblyKind.Skia).IsAlreadyPatched, secondResult.Output);
+
+        var secondLines = File.ReadAllLines(capturePath);
+        Assert.Contains(secondLines, line => line.StartsWith(stagedBasePath + "|", StringComparison.Ordinal));
+        Assert.Contains(secondLines, line => line.StartsWith(stagedSkiaPath + "|", StringComparison.Ordinal));
+    }
+
     private static void CreateAndroidPatchHarnessProject(string projectPath, string intermediateOutputPath)
     {
         var project = new XDocument(
@@ -79,6 +158,47 @@ public sealed class EffectorBuildTargetsTests
                     new XElement("IntermediateOutputPath", EnsureTrailingSeparator(intermediateOutputPath)),
                     new XElement("_EffectorPackagedTaskAssemblyPath", GetBuiltTaskAssemblyPath())),
                 new XElement("Import", new XAttribute("Project", GetBuildTargetsPath()))));
+
+        project.Save(projectPath);
+    }
+
+    private static void CreateBrowserPatchHarnessProject(
+        string projectPath,
+        string intermediateOutputPath,
+        string avaloniaBasePath,
+        string avaloniaSkiaPath,
+        string capturePath)
+    {
+        var project = new XDocument(
+            new XElement(
+                "Project",
+                new XAttribute("Sdk", "Microsoft.NET.Sdk"),
+                new XElement("Import", new XAttribute("Project", GetBuildPropsPath())),
+                new XElement(
+                    "PropertyGroup",
+                    new XElement("TargetFramework", "net8.0"),
+                    new XElement("RuntimeIdentifier", "browser-wasm"),
+                    new XElement("Configuration", "Debug"),
+                    new XElement("EffectorEnabled", "true"),
+                    new XElement("EffectorVerbose", "true"),
+                    new XElement("IntermediateOutputPath", EnsureTrailingSeparator(intermediateOutputPath)),
+                    new XElement("CaptureReferenceCopyLocalPathsFile", capturePath),
+                    new XElement("_EffectorPackagedTaskAssemblyPath", GetBuiltTaskAssemblyPath())),
+                new XElement(
+                    "ItemGroup",
+                    CreateBrowserReferenceCopyLocalPath(avaloniaBasePath, "Avalonia.Base.dll"),
+                    CreateBrowserReferenceCopyLocalPath(avaloniaSkiaPath, "Avalonia.Skia.dll")),
+                new XElement("Import", new XAttribute("Project", GetBuildTargetsPath())),
+                new XElement(
+                    "Target",
+                    new XAttribute("Name", "CaptureReferenceCopyLocalPaths"),
+                    new XElement(
+                        "WriteLinesToFile",
+                        new XAttribute("File", "$(CaptureReferenceCopyLocalPathsFile)"),
+                        new XAttribute(
+                            "Lines",
+                            "@(ReferenceCopyLocalPaths->'%(Identity)|%(DestinationSubDirectory)|%(DestinationSubPath)|%(AssetType)|%(CopyToPublishDirectory)')"),
+                        new XAttribute("Overwrite", "true")))));
 
         project.Save(projectPath);
     }
@@ -126,6 +246,19 @@ public sealed class EffectorBuildTargetsTests
             sourceFilePath);
     }
 
+    private static string GetBuildPropsPath([CallerFilePath] string sourceFilePath = "")
+    {
+        return ResolveRepositoryFile(
+            new[]
+            {
+                "src",
+                "Effector.Build",
+                "buildTransitive",
+                "Effector.Build.props"
+            },
+            sourceFilePath);
+    }
+
     private static string GetBuiltTaskAssemblyPath([CallerFilePath] string sourceFilePath = "")
     {
         var configuration =
@@ -162,6 +295,23 @@ public sealed class EffectorBuildTargetsTests
         path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
             ? path
             : path + Path.DirectorySeparatorChar;
+
+    private static XElement CreateBrowserReferenceCopyLocalPath(string assemblyPath, string fileName)
+    {
+        return new XElement(
+            "ReferenceCopyLocalPaths",
+            new XAttribute("Include", assemblyPath),
+            new XElement("DestinationSubDirectory", "_framework\\"),
+            new XElement("DestinationSubPath", "_framework\\" + fileName),
+            new XElement("AssetType", "runtime"),
+            new XElement("Private", "true"),
+            new XElement("CopyToPublishDirectory", "PreserveNewest"),
+            new XElement("CopyToOutputDirectory", "PreserveNewest"),
+            new XElement("NuGetPackageId", "Avalonia"),
+            new XElement("NuGetPackageVersion", "12.0.0"),
+            new XElement("ReferenceSourceTarget", "PackageReference"),
+            new XElement("ResolvedFrom", "NuGetPackage"));
+    }
 
     private static string ResolveRepositoryFile(string[] relativePathSegments, string sourceFilePath)
     {


### PR DESCRIPTION
# PR Summary: Browser-WASM Avalonia Patching Lane

## Overview

This change fixes the browser-wasm packaging gap in Effector's current patch-based integration while preserving the existing IL-weaving model and the desktop/mobile/AOT patch lanes.

The core issue was that Effector patched `Avalonia.Base.dll` and `Avalonia.Skia.dll` too late for browser-wasm. The browser SDK builds `_framework` from resolved copy-local and publish inputs, not from the final patched `$(TargetDir)` outputs. As a result, the browser bundle could still contain unpatched Avalonia assemblies even though local build output had already been rewritten.

This PR moves the browser-wasm patch lane upstream into the actual browser input pipeline by staging patched copies from `@(ReferenceCopyLocalPaths)` and then rewriting the reference items to point at those staged assemblies before static web assets and publish inputs are computed.

## What Changed

### 1. Added a browser-wasm patch switch

In `src/Effector.Build/buildTransitive/Effector.Build.props`:

- added `EffectorPatchBrowserWasmAssemblies`
- default value is `true`

This keeps the browser-wasm lane opt-out instead of opt-in and mirrors the current behavior of Effector's other patch lanes.

### 2. Added browser-wasm target detection and staging paths

In `src/Effector.Build/buildTransitive/Effector.Build.targets`:

- added `_EffectorIsBrowserWasm`
- added `_EffectorBrowserPatchedAssemblyDir`

These derived properties are intentionally evaluated in `targets`, not `props`, because they depend on final project properties such as `RuntimeIdentifier` and `IntermediateOutputPath`.

### 3. Added a new browser-wasm patch target

New target:

- `Effector_PatchAvaloniaBrowserReferenceInputs`

Execution point:

- `AfterTargets="ResolveReferences"`
- `BeforeTargets="ResolveBuildRelatedStaticWebAssets;CopyFilesToOutputDirectory;ComputeFilesToPublish;StaticWebAssetsPrepareForPublish"`

Behavior:

1. Finds `Avalonia.Base.dll` and `Avalonia.Skia.dll` inside `@(ReferenceCopyLocalPaths)`.
2. Fails fast if either assembly is missing or duplicated.
3. Copies both assemblies to `$(IntermediateOutputPath)/effector-browser-patched`.
4. Copies adjacent PDB files when present.
5. Runs the existing `PatchAvaloniaAssembliesTask` against the staged copies.
6. Removes the original Avalonia entries from `@(ReferenceCopyLocalPaths)`.
7. Re-adds patched staged copies while preserving the metadata needed by downstream browser SDK logic.
8. Records staged files in `@(FileWrites)` for cleanup support.

### 4. Prevented double-handling on browser-wasm

The existing late patch targets now skip browser-wasm:

- `Effector_PatchAvaloniaOutputAssemblies`
- `Effector_PatchAvaloniaPublishAssemblies`

That keeps the browser lane single-sourced and avoids patching a second, irrelevant location after `_framework` inputs have already been chosen.

### 5. Added browser-specific regression coverage

In `tests/Effector.Build.Tasks.Tests/EffectorBuildTargetsTests.cs`:

- added a browser-wasm harness test for `Effector_PatchAvaloniaBrowserReferenceInputs`
- verifies staged assemblies are created
- verifies staged assemblies are patched
- verifies rewritten `ReferenceCopyLocalPaths` points at staged assemblies
- verifies browser metadata such as `_framework`, `runtime`, and `PreserveNewest` survives the rewrite
- verifies the original source copies remain unmodified
- verifies the target can run a second time without corrupting the rewritten state

The existing Android target test still passes, which gives confidence that the new browser conditions did not regress the Android lane.

### 6. Added planning documentation

Committed a new plan file:

- `plan/browser-wasm-patching.md`

It captures both:

- the implemented browser-wasm MSBuild fix for issue `#24`
- the longer-term runtime-only second integration method for issue `#25`

## Why This Approach

This PR intentionally does not introduce a runtime-only implementation yet.

That work is still valid and documented, but it solves a different problem:

- issue `#24` is about the current patched lane missing the browser-wasm bundle pipeline
- issue `#25` is about supporting a second, non-patching integration method on all platforms

For `#24`, the smallest correct fix is to patch the actual browser bundle inputs instead of the final output directory. That preserves the current `Visual.Effect` architecture and keeps behavior aligned with desktop and Android.

## Commit Breakdown

### Commit 1

`e625955` `Add browser-wasm Avalonia patching target`

Contains:

- new browser-wasm property switch
- browser detection/staging properties
- new `Effector_PatchAvaloniaBrowserReferenceInputs` target
- skip conditions for late output/publish patch targets on browser-wasm

### Commit 2

`39db34e` `Add browser-wasm patch target coverage`

Contains:

- browser-wasm build-task harness
- metadata preservation assertions
- source assembly immutability assertions
- repeat-run regression coverage

### Commit 3

`6f97429` `Add browser-wasm and runtime-only planning notes`

Contains:

- cross-platform plan for issue `#25`
- concrete browser-wasm implementation notes for issue `#24`

## Validation

Executed:

```bash
dotnet test tests/Effector.Build.Tasks.Tests/Effector.Build.Tasks.Tests.csproj -m:1
```

Result:

- all 12 tests passed

## Known Remaining Gap

This PR validates the browser lane at the build-task level, not with a full end-to-end browser sample build/publish assertion.

The next useful follow-up would be an integration smoke test that verifies:

- non-WebCIL browser output consumes patched Avalonia assemblies
- WebCIL browser output also consumes the staged patched inputs

## Suggested PR Description

This PR fixes Effector's browser-wasm patch pipeline by patching the actual browser bundle inputs instead of the final `bin` output. It adds a new MSBuild target that stages and patches `Avalonia.Base.dll` and `Avalonia.Skia.dll` from `ReferenceCopyLocalPaths`, then rewrites those items before static web assets and publish inputs are computed. The change preserves the existing IL-weaving and patched `Visual.Effect` architecture, keeps Android and AOT lanes unchanged, and adds regression coverage for metadata preservation, source-copy safety, and repeat target execution.
